### PR TITLE
Arcade review fixes: resume rAF freeze + timer accrual + offline assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,7 +373,7 @@ body {
 .pi-digit { display: inline-block; animation: digit-pop 0.25s ease-out; }
 .pi-digit.latest { color: var(--success-color); text-shadow: 0 0 10px var(--success-color); }
 [data-theme="orbital"] .pi-digit {
-  animation: digit-pop 0.25s ease-out, orbital-float 3s ease-in-out infinite;
+  animation: digit-pop 0.25s ease-out, orbital-float calc(3s * var(--motion-scale, 1)) ease-in-out infinite;
   animation-delay: 0s, calc(var(--digit-index, 0) * 0.1s);
 }
 
@@ -400,7 +400,7 @@ body {
 .numpad-btn.correct-flash { border-color: var(--success-color) !important; box-shadow: 0 0 20px rgba(0, 255, 136, 0.4) !important; }
 .numpad-btn.wrong-flash { border-color: var(--error-color) !important; box-shadow: 0 0 20px rgba(255, 51, 102, 0.5) !important; background: rgba(255, 51, 102, 0.2) !important; }
 .numpad-btn.zero-btn { grid-column: 2; }
-.numpad.combo-active .numpad-btn { animation: pulse-glow 0.8s ease-in-out infinite; }
+.numpad.combo-active .numpad-btn { animation: pulse-glow calc(0.8s * var(--motion-scale, 1)) ease-in-out infinite; }
 
 /* ===== Theme-Specific Overrides ===== */
 
@@ -432,13 +432,13 @@ body {
     transparent 100%
   );
   background-size: 100% 30%;
-  animation: neural-scanline 8s linear infinite;
+  animation: neural-scanline calc(8s * var(--motion-scale, 1)) linear infinite;
 }
 /* Orbital: subtle pulsing nebula */
 [data-theme="orbital"] .theme-overlay {
   opacity: 1;
   background: radial-gradient(ellipse at 30% 40%, rgba(124,92,252,0.06), transparent 50%);
-  animation: orbital-twinkle 6s ease-in-out infinite;
+  animation: orbital-twinkle calc(6s * var(--motion-scale, 1)) ease-in-out infinite;
 }
 
 /* ===== Theme Button Previews ===== */

--- a/index.html
+++ b/index.html
@@ -954,26 +954,13 @@ function drawAppIcon(size) {
 }
 
 function generateAppIcons() {
-  // apple-touch-icon (180px)
+  // apple-touch-icon (180px) — iOS ignores manifest.json icons, so this stays
+  // a dynamically drawn data URI. The manifest itself is left alone (static
+  // manifest.json already ships a real icon.svg); no blob: URL swap.
   const link180 = document.createElement('link');
   link180.rel = 'apple-touch-icon'; link180.sizes = '180x180';
   link180.href = drawAppIcon(180);
   document.head.appendChild(link180);
-  // Generate dynamic manifest with embedded icon data URIs
-  const icon192 = drawAppIcon(192), icon512 = drawAppIcon(512);
-  const manifest = {
-    name: 'Pi Game', short_name: 'Pi Game',
-    description: 'How many digits of Pi can you recite?',
-    start_url: './', scope: './', display: 'standalone',
-    background_color: '#0a0a0f', theme_color: '#0a0a0f', orientation: 'portrait',
-    icons: [
-      { src: icon192, sizes: '192x192', type: 'image/png' },
-      { src: icon512, sizes: '512x512', type: 'image/png' }
-    ]
-  };
-  const blob = new Blob([JSON.stringify(manifest)], { type: 'application/json' });
-  const manifestLink = document.querySelector('link[rel="manifest"]');
-  if (manifestLink) manifestLink.href = URL.createObjectURL(blob);
 }
 
 // ===== Pi Digits =====

--- a/index.html
+++ b/index.html
@@ -970,11 +970,18 @@ const PI_DIGITS = '1415926535897932384626433832795028841971693993751058209749445
 // Leaderboard lives in Arcade.scores('classic'), not in this blob, so it
 // rides the launcher's save/load bundling and inherits the player name.
 const DEFAULT_STATE = {
-  gameState: 'MENU', currentTheme: 'neural', piSequence: PI_DIGITS,
-  userSequence: '', startTime: null, soundEnabled: true, cameraFollow: false
+  gameState: 'MENU', currentTheme: 'neural',
+  userSequence: '', soundEnabled: true, cameraFollow: false
 };
 let state = { ...DEFAULT_STATE };
 let timerInterval = null, lastPressTime = 0, comboLevel = 0, lastGameScore = 0;
+// Elapsed run time lives in its own persisted key via the session timer, not
+// in the state blob — it self-pauses across suspend/hidden time and re-syncs
+// on launcher-driven state imports, unlike a hand-rolled Date.now() epoch.
+// Registered here (module scope, before Arcade.onSuspend/onResume/onStateReplaced
+// below) so its internal lifecycle listeners run first and stay in sync.
+const sessionTimer = Arcade.session.start({ persistKey: 'elapsedMs' });
+sessionTimer.pause();
 
 // ===== Audio =====
 let audioCtx = null;
@@ -1115,7 +1122,6 @@ function triggerErrorParticles(el) {
 function saveState() { Arcade.state.set('state', state); }
 function loadState() {
   state = Arcade.state.getOrInit('state', DEFAULT_STATE);
-  state.piSequence = PI_DIGITS;
 }
 
 // One-shot migration of legacy localStorage keys into the namespaced layout.
@@ -1230,7 +1236,7 @@ $themeButtons.forEach(b => b.addEventListener('click', () => applyTheme(b.datase
 function startTimer() {
   stopTimer();
   timerInterval = setInterval(() => {
-    if (state.startTime) $timerDisplay.textContent = ((Date.now() - state.startTime) / 1000).toFixed(1) + 's';
+    $timerDisplay.textContent = (sessionTimer.elapsedMs() / 1000).toFixed(1) + 's';
   }, 100);
 }
 function stopTimer() { if (timerInterval) { clearInterval(timerInterval); timerInterval = null; } }
@@ -1248,16 +1254,17 @@ function renderPiDigits() {
 
 // ===== Game Logic =====
 function startGame() {
-  state.gameState = 'PLAYING'; state.userSequence = ''; state.startTime = null;
+  state.gameState = 'PLAYING'; state.userSequence = '';
   comboLevel = 0; lastPressTime = 0; saveState(); renderPiDigits();
+  sessionTimer.pause(); sessionTimer.reset();
   $timerDisplay.textContent = '0.0s'; showScreen('game-screen');
   if (typeof currentVisual !== 'undefined' && currentVisual) currentVisual.reset();
 }
 
 function handleDigitPress(digit, btn) {
   if (state.gameState !== 'PLAYING') return;
-  const idx = state.userSequence.length, expected = state.piSequence[idx];
-  if (!state.startTime) { state.startTime = Date.now(); startTimer(); }
+  const idx = state.userSequence.length, expected = PI_DIGITS[idx];
+  if (idx === 0) { sessionTimer.reset(); sessionTimer.resume(); startTimer(); }
   const now = Date.now();
   if (lastPressTime && (now - lastPressTime) < 400) comboLevel++; else comboLevel = Math.max(0, comboLevel - 1);
   lastPressTime = now;
@@ -1275,9 +1282,9 @@ function handleDigitPress(digit, btn) {
 }
 
 function gameOver(btn) {
-  state.gameState = 'GAME_OVER'; stopTimer();
+  state.gameState = 'GAME_OVER'; stopTimer(); sessionTimer.pause();
   const score = state.userSequence.length; lastGameScore = score;
-  const timeMs = state.startTime ? Date.now() - state.startTime : 0;
+  const timeMs = sessionTimer.elapsedMs();
   const timeSec = (timeMs / 1000).toFixed(1);
   playWrongSound();
   if (!Arcade.settings.reducedMotion()) {
@@ -1290,7 +1297,7 @@ function gameOver(btn) {
       meta: { time: parseFloat(timeSec), date: new Date().toLocaleDateString() }
     });
   }
-  state.userSequence = ''; state.startTime = null; saveState();
+  state.userSequence = ''; saveState();
   setTimeout(() => {
     $finalScore.textContent = score; $finalTime.textContent = timeSec;
     renderLeaderboard($gameoverLbList); renderAutopsy(score); showScreen('gameover-screen');
@@ -1501,7 +1508,8 @@ Arcade.onSuspend(() => {
 });
 Arcade.onResume(() => {
   if (audioCtx && audioCtx.state === 'suspended') audioCtx.resume();
-  if (state.gameState === 'PLAYING' && state.startTime) startTimer();
+  if (state.gameState === 'PLAYING' && state.userSequence.length > 0) startTimer();
+  ensureAnimationLoop();
 });
 
 // Launcher imported a save while we were running — re-hydrate from disk.
@@ -1511,10 +1519,9 @@ Arcade.onStateReplaced(() => {
   updateSoundBtn();
   if (state.gameState === 'PLAYING' && state.userSequence.length > 0) {
     renderPiDigits();
-    if (state.startTime) {
-      $timerDisplay.textContent = ((Date.now() - state.startTime) / 1000).toFixed(1) + 's';
-      startTimer();
-    }
+    sessionTimer.resume();
+    $timerDisplay.textContent = (sessionTimer.elapsedMs() / 1000).toFixed(1) + 's';
+    startTimer();
     showScreen('game-screen');
   } else {
     if (state.gameState === 'GAME_OVER') { state.gameState = 'MENU'; saveState(); }
@@ -1531,7 +1538,9 @@ function init() {
   placeBrandLogos(); generateAppIcons();
   if (state.gameState === 'PLAYING' && state.userSequence.length > 0) {
     renderPiDigits();
-    if (state.startTime) { $timerDisplay.textContent = ((Date.now()-state.startTime)/1000).toFixed(1)+'s'; startTimer(); }
+    sessionTimer.resume();
+    $timerDisplay.textContent = (sessionTimer.elapsedMs() / 1000).toFixed(1) + 's';
+    startTimer();
     showScreen('game-screen');
   } else { if (state.gameState === 'GAME_OVER') { state.gameState = 'MENU'; saveState(); } showScreen('start-screen'); }
 }

--- a/sw.js
+++ b/sw.js
@@ -1,12 +1,17 @@
 // Pi Game — Service Worker
 // Caches all assets for offline play after first load.
 
-const CACHE_NAME = 'pi-game-v2';
+const CACHE_NAME = 'pi-game-v3';
 const ASSETS = [
   './',
   './index.html',
   './manifest.json',
   './icon.svg',
+  './visuals/tracer.js?v=2',
+  './visuals/spirograph.js?v=2',
+  './visuals/gallery.js?v=4',
+  './visuals/orbital.js?v=2',
+  './visuals/manager.js?v=2',
 ];
 
 self.addEventListener('install', event => {
@@ -39,8 +44,18 @@ self.addEventListener('fetch', event => {
     );
     return;
   }
-  // Cache-first for static assets
+  // Cache-first for static assets; cache successful fetches too, so assets
+  // missing from ASSETS (or added later) still work offline next time.
   event.respondWith(
-    caches.match(event.request).then(cached => cached || fetch(event.request))
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request).then(response => {
+        if (response.ok) {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(c => c.put(event.request, clone));
+        }
+        return response;
+      });
+    })
   );
 });

--- a/visuals/gallery.js
+++ b/visuals/gallery.js
@@ -145,6 +145,14 @@ class GalleryVisual {
   }
 
   update() {
+    if (Arcade.settings.reducedMotion()) {
+      // Snap the camera straight to its target instead of continuously panning/zooming.
+      this.zoomScale = this.targetZoomScale;
+      this.focusX = this.targetFocusX;
+      this.focusY = this.targetFocusY;
+      this.moving = false;
+      return false;
+    }
     let active = false;
     const zRate = 0.16, fRate = 0.16;
     if (Math.abs(this.zoomScale - this.targetZoomScale) / Math.max(this.zoomScale, 1) > 0.002) {

--- a/visuals/orbital.js
+++ b/visuals/orbital.js
@@ -83,41 +83,52 @@ class OrbitalVisual {
   }
 
   update() {
-    this.time++;
+    // Reduced motion: still place every body (so newly fed digits render),
+    // but freeze orbits, trails and camera drift instead of advancing them.
+    const reduced = Arcade.settings.reducedMotion();
+    if (!reduced) this.time++;
     let active = false;
     let newest = null;
 
     for (const b of this.bodies) {
       if (b.type === 'flare') {
-        if (b.age < 150) { b.age++; active = true; }
+        if (!reduced && b.age < 150) { b.age++; active = true; }
       } else if (b.type === 'comet') {
-        b.angle += b.speed;
+        if (!reduced) b.angle += b.speed;
         const r = b.a * (1 - b.e * b.e) / (1 + b.e * Math.cos(b.angle));
         const lx = Math.cos(b.angle) * r;
         const ly = Math.sin(b.angle) * r;
         const c = Math.cos(b.axisRotation), s = Math.sin(b.axisRotation);
         b.x = lx * c - ly * s;
         b.y = lx * s + ly * c;
-        b.trail.push({ x: b.x, y: b.y });
-        if (b.trail.length > 60) b.trail.shift();
-        active = true;
+        if (!reduced) {
+          b.trail.push({ x: b.x, y: b.y });
+          if (b.trail.length > 60) b.trail.shift();
+          active = true;
+        }
         newest = { x: b.x, y: b.y };
       } else {
-        b.angle += b.speed;
+        if (!reduced) b.angle += b.speed;
         b.x = Math.cos(b.angle) * b.distance;
         b.y = Math.sin(b.angle) * b.distance;
-        b.trail.push({ x: b.x, y: b.y });
-        if (b.trail.length > b.maxTrail) b.trail.shift();
-        active = true;
+        if (!reduced) {
+          b.trail.push({ x: b.x, y: b.y });
+          if (b.trail.length > b.maxTrail) b.trail.shift();
+          active = true;
+        }
         newest = { x: b.x, y: b.y };
       }
     }
 
     const target = (state.cameraFollow && newest) ? newest : { x: 0, y: 0 };
-    this.focusX += (target.x - this.focusX) * 0.04;
-    this.focusY += (target.y - this.focusY) * 0.04;
+    if (reduced) {
+      this.focusX = target.x; this.focusY = target.y;
+    } else {
+      this.focusX += (target.x - this.focusX) * 0.04;
+      this.focusY += (target.y - this.focusY) * 0.04;
+    }
 
-    if (this.bodies.length > 0) active = true;
+    if (this.bodies.length > 0 && !reduced) active = true;
     return active;
   }
 

--- a/visuals/spirograph.js
+++ b/visuals/spirograph.js
@@ -41,7 +41,8 @@ class SpirographVisual {
   }
 
   update() {
-    this.time++;
+    const reduced = Arcade.settings.reducedMotion();
+    if (!reduced) this.time++;
 
     // Camera zoom shrinks as tiles spread further. Tiles themselves stay fixed size on screen.
     let maxR = this.SHAPE_R;
@@ -51,6 +52,15 @@ class SpirographVisual {
     const buffer = this.SHAPE_R * 1.05;
     const fit = (this.viewMin / 2 - buffer) / maxR;
     this.targetScale = Math.max(0.04, Math.min(this.MAX_SCALE, fit));
+
+    if (reduced) {
+      // Snap zoom and every tile straight to their resting state instead of
+      // continuously lerping/unrolling.
+      this.scale = this.targetScale;
+      for (const e of this.elements) { e.drawProgress = 1; e.pulse = 0; }
+      return false;
+    }
+
     this.scale += (this.targetScale - this.scale) * 0.06;
 
     let active = false;

--- a/visuals/tracer.js
+++ b/visuals/tracer.js
@@ -52,6 +52,12 @@ class TracerVisual {
     ensureAnimationLoop();
   }
   update() {
+    if (Arcade.settings.reducedMotion()) {
+      // Snap straight to the resting position instead of continuously lerping.
+      this.x = this.targetX; this.y = this.targetY;
+      this.moving = false;
+      return false;
+    }
     let active = false;
     const dx = this.targetX - this.x, dy = this.targetY - this.y;
     if (Math.abs(dx) > window.innerWidth / 2 || Math.abs(dy) > window.innerHeight / 2) {


### PR DESCRIPTION
Addresses #14.

## Fixed
- **Resume never restarted the rAF loop** — active scenes froze after suspend/resume until a keypress. `Arcade.onResume` now calls `ensureAnimationLoop()`.
- **Hand-rolled timer accrued while hidden/evicted** — replaced the `Date.now()` epoch + interval with `Arcade.session.start({ persistKey: 'elapsedMs' })`.
- Reduced motion was only partially honored — ambient CSS animations now scale by `--motion-scale`; canvas visuals (orbital/tracer/spirograph/gallery) snap to rest and stop requesting frames.
- Service worker couldn't actually deliver offline play — `visuals/*.js` are now cached, and successful fetches get cache-put; bumped `CACHE_NAME`.
- Dropped the persisted 1000-digit `piSequence` from the state blob (rides every save/export for no reason) and the runtime blob-URL manifest hack (kept the static manifest + existing `icon.svg`).

## Not in this PR
- Stale vendored `arcade-sdk.js` — confirmed dev-tooling only (`go.sh` overwrites it each run, gitignored, never ships).

Verified live against a running instance (Playwright): rAF resumes after suspend, elapsed time freezes while hidden and resumes correctly, reduced-motion visuals hold valid state, all 5 visual scripts land in the SW cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)