### PR TITLE
fix: guard raw localStorage reads in the legacy migration (fixes #16)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1141,11 +1141,15 @@ function migrateLegacyState() {
     const legacyKeys = ['piGameState', 'arcade.v1.pi-game.ls.piGameState'];
     let parsed = null;
     for (const k of legacyKeys) {
-      const raw = localStorage.getItem(k);
+      // Guarded: in a launcher-sandboxed (opaque-origin) frame, touching
+      // localStorage throws SecurityError. Legacy pre-SDK keys are
+      // unreachable there by design — treat as nothing to migrate.
+      let raw = null;
+      try { raw = localStorage.getItem(k); } catch (e) {}
       if (raw) {
         try { parsed = JSON.parse(raw); } catch (e) {}
       }
-      localStorage.removeItem(k);
+      try { localStorage.removeItem(k); } catch (e) {}
     }
     // Also salvage from any state already written under the new key (e.g. a
     // previous SDK build that hadn't yet split out scores).


### PR DESCRIPTION
In a launcher-sandboxed (opaque-origin) frame, touching localStorage throws
SecurityError — the unguarded reads made migrate('v1') throw and retry with
a console error on every framed boot, and the sentinel was never written.
Legacy pre-SDK keys are unreachable in frames by design: treat them as
nothing-to-migrate (hecknsic's take() pattern) so the migration completes.

Verified in the staged launcher: _migrated.v1 sentinel now written through
the storage bridge, no SDK errors at boot.

Fixes #16.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
