### PR TITLE
Symlink the dev SDK instead of copying it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .go.log
 .go.pid
 arcade-sdk.js
-.arcade-stage/

--- a/go.sh
+++ b/go.sh
@@ -6,13 +6,15 @@ PID_FILE="$DIR/.go.pid"
 LOG_FILE="$DIR/.go.log"
 PORT=8790
 
-# Mirror the Arcade SDK from the sibling launcher repo so /arcade-sdk.js
-# resolves when serving pi-game in isolation. In production both live at the
-# same origin (paulgibeault.github.io); this preserves that invariant locally.
+# Symlink (never copy) the Arcade SDK from the sibling launcher repo so
+# /arcade-sdk.js resolves when serving pi-game in isolation — a link can't go
+# stale, and cp onto an existing symlink-to-source errors out under set -e.
+# In production both live at the same origin (paulgibeault.github.io); this
+# preserves that invariant locally.
 SDK_SRC="$DIR/../paulgibeault.github.io/arcade-sdk.js"
 SDK_DST="$DIR/arcade-sdk.js"
 if [ -f "$SDK_SRC" ]; then
-  cp "$SDK_SRC" "$SDK_DST"
+  ln -sfn "$SDK_SRC" "$SDK_DST"
 else
   echo "WARNING: $SDK_SRC not found — pi-game will fail to load Arcade SDK." >&2
   echo "         Clone paulgibeault/paulgibeault.github.io as a sibling directory." >&2


### PR DESCRIPTION
Part of the fleet duplication hygiene sweep: no copied arcade JS anywhere.

- `go.sh` copied `arcade-sdk.js` from the sibling launcher on every run — a stale snapshot between runs, and since the working copy on disk was already a symlink to the launcher's file, `cp` onto it errors ("identical files") and kills the script under `set -euo pipefail`. Now `ln -sfn` — never stale, idempotent, and python's http.server follows it fine. Verified by running the block: link created/refreshed correctly.
- Removed the dead `.arcade-stage/` ignore line and deleted the orphaned dir (retired staging scheme — launcher `dev.sh` stages into its own `.dev-stage` now; nothing references `.arcade-stage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)