### PR TITLE
Re-tune SFX around a metronome/alarm sound identity

### DIFF
--- a/index.html
+++ b/index.html
@@ -989,38 +989,65 @@ sessionTimer.pause();
 // the global mute button), and suspend-on-hide / resume-on-return — so none of
 // that lives here anymore. This game keeps only its own in-game mute toggle
 // (state.soundEnabled) as an extra gate; volume itself is launcher-owned.
-// Cue specs port the previous oscillator parameters (type/freq/dur/gain)
-// verbatim so each sound is recognisably the same; the SDK applies its own
-// safe linear-ramp envelope in place of the old exponentialRamp-to-0.001.
+//
+// Sound identity: a recital under pressure. 'correct' is a metronome tick that
+// keeps time *under* the player's concentration, never a reward chime; 'wrong'
+// is an alarm strike that ends the run. Everything else is a sibling of one of
+// those two. The game asks for hundreds of keystrokes in a row, so the tick's
+// first duty is to stay out of the way — unobtrusive beats interesting.
 if (window.Arcade && Arcade.audio) {
   Arcade.audio
-    // Correct digit: sine, base 440 Hz. freq rises with digit index per play
-    // (Math.min(440 + idx*8, 1200)); see playCorrect() below.
-    .cue('correct', { type: 'sine', freq: 440, dur: 0.12, gain: 0.15 })
-    // Combo sparkle layered over 'correct' when the streak is hot (comboLevel
-    // > 3): triangle a fifth up, gain scaled per play by Math.min(combo, 10).
-    .cue('combo', { type: 'triangle', freq: 660, dur: 0.15, gain: 0.05 })
-    // Wrong digit / game over: three detuned sawtooth voices as a chord.
+    // Correct digit — the metronome tick. Triangle (a touch more edge than a
+    // sine, so it reads as a click rather than a beep), near-instant attack and
+    // a 70 ms fall to silence: percussive, and short enough that fast typing
+    // never smears one tick into the next. Stays a SINGLE-object spec because
+    // playCorrect() overrides `freq` per play for the rising digit-index ladder
+    // (Math.min(440 + idx*8, 1200)) and the SDK only merges overrides onto
+    // single-object cues — an array would silently drop the ladder. For the
+    // same reason there is no `toFreq` bend: a fixed target would mean a
+    // different-sized bend at every rung of the ladder.
+    .cue('correct', { type: 'triangle', freq: 440, dur: 0.07, gain: 0.14, attack: 0.001, release: 0.065 })
+    // Hot-streak accent layered over 'correct' (comboLevel > 3): a clean sine
+    // ping a fifth above the tick, decaying the whole way out. Also single-
+    // object — playCorrect() overrides both `freq` and `gain` per play, so it
+    // scales with the streak. It is an accent on the tick, not a second cue:
+    // it must stay quieter than the tick it rides on at every streak level.
+    .cue('combo', { type: 'sine', freq: 660, dur: 0.09, gain: 0.05, attack: 0.001, release: 0.085 })
+    // Wrong digit / game over — the alarm strike. A noise transient and a
+    // pitch-dropping triangle land together as the hit; 20 ms later the detuned
+    // sawtooth cluster sags in and holds, all three voices bending downward so
+    // the run audibly dies instead of resolving into an organ chord. The only
+    // long cue in the game, and it fires exactly once per run.
     .cue('wrong', [
-      { type: 'sawtooth', freq: 150, dur: 0.5, gain: 0.12, delay: 0 },
-      { type: 'sawtooth', freq: 157, dur: 0.5, gain: 0.12, delay: 0 },
-      { type: 'sawtooth', freq: 185, dur: 0.5, gain: 0.12, delay: 0 },
+      { type: 'noise', dur: 0.045, gain: 0.10, attack: 0.001, release: 0.044, delay: 0 },
+      { type: 'triangle', freq: 200, toFreq: 55, dur: 0.18, gain: 0.16, attack: 0.001, release: 0.16, delay: 0 },
+      { type: 'sawtooth', freq: 150, toFreq: 138, dur: 0.5, gain: 0.08, attack: 0.006, release: 0.34, delay: 0.02 },
+      { type: 'sawtooth', freq: 157, toFreq: 144, dur: 0.5, gain: 0.08, attack: 0.006, release: 0.34, delay: 0 },
+      { type: 'sawtooth', freq: 185, toFreq: 170, dur: 0.5, gain: 0.07, attack: 0.006, release: 0.34, delay: 0 },
     ])
-    // Practice mode feedback (softer/shorter than the main game cues).
-    .cue('practice-correct', { type: 'sine', freq: 600, dur: 0.08, gain: 0.08 })
-    .cue('practice-wrong', { type: 'square', freq: 200, dur: 0.2, gain: 0.1 });
+    // Practice mode — the same two sounds with the stakes taken out: a quieter,
+    // shorter tick, and a strike reduced to its impact with no alarm tail,
+    // because nothing ends here. Both play without overrides, so 'practice-
+    // wrong' is free to be an array.
+    .cue('practice-correct', { type: 'triangle', freq: 600, dur: 0.055, gain: 0.075, attack: 0.001, release: 0.05 })
+    .cue('practice-wrong', [
+      { type: 'noise', dur: 0.03, gain: 0.06, attack: 0.001, release: 0.029, delay: 0 },
+      { type: 'triangle', freq: 180, toFreq: 90, dur: 0.14, gain: 0.10, attack: 0.001, release: 0.12, delay: 0 },
+    ]);
 }
 // A2 wrapper — the single guarded play-site. Feature-detects Arcade.audio and
 // gates on the in-game mute toggle (state.soundEnabled).
 const sfx = (name, opts) => {
   if (window.Arcade && Arcade.audio && state.soundEnabled) Arcade.audio.play(name, opts);
 };
-// Correct-digit cue with the rising pitch + hot-streak sparkle ported as
-// per-play overrides.
+// The tick, pitched by how deep into Pi you are, plus the streak accent above
+// it. Both ride per-play overrides (see the single-object cues above). The
+// accent's gain grows with the streak but tops out below the tick's own 0.14,
+// so a hot streak colours the metronome rather than shouting over it.
 function playCorrect(digitIndex) {
   const freq = Math.min(440 + digitIndex * 8, 1200);
   sfx('correct', { freq });
-  if (comboLevel > 3) sfx('combo', { freq: freq * 1.5, gain: 0.05 * Math.min(comboLevel, 10) });
+  if (comboLevel > 3) sfx('combo', { freq: freq * 1.5, gain: 0.012 * Math.min(comboLevel, 10) });
 }
 
 // ===== Particles =====

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
 // Pi Game — Service Worker
 // Caches all assets for offline play after first load.
 
-const CACHE_NAME = 'pi-game-v4';
+const CACHE_NAME = 'pi-game-v5';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
**Sound identity:** a tense recital — `correct` is a metronome tick that keeps time *under* the player's concentration, and `wrong` is an alarm strike that ends the run; every other cue is a sibling of one of those two.

The cues were previously carried over verbatim from the game's original hand-rolled synth. Being hand-written made them deliberate, but they still predate any sound-identity thinking: a stock 440 Hz sine beep for every correct digit and a static detuned-saw organ chord for the loss. Neither says "one wrong digit and it's over."

## Per-cue before → after

| Cue | Before | After | Why |
|---|---|---|---|
| `correct` | `sine 440 Hz, dur 0.12, gain 0.15` (default envelope) | `triangle 440 Hz, dur 0.07, gain 0.14, attack 0.001, release 0.065` | Metronome tick. Triangle gives enough edge to read as a click rather than a beep; near-instant attack and a 65 ms fall to silence make it percussive and short enough that fast typing never smears one tick into the next. Fires on **every** keystroke of a long recital, so unobtrusive outranks interesting. Stays single-object — `playCorrect()` overrides `freq` for the rising digit-index ladder (`Math.min(440 + idx*8, 1200)`), which array cues would silently drop. |
| `combo` | `triangle 660 Hz, dur 0.15, gain 0.05`; played with `gain: 0.05 * min(combo,10)` | `sine 660 Hz, dur 0.09, gain 0.05, attack 0.001, release 0.085`; played with `gain: 0.012 * min(combo,10)` | A clean ping a fifth above the tick, decaying the whole way out. Still single-object so both per-play overrides keep working, still scaled by `min(comboLevel, 10)`. |
| `wrong` | 3× `sawtooth 150/157/185 Hz, dur 0.5, gain 0.12`, flat, all `delay: 0` | `noise 0.045s @0.10` + `triangle 200→55 Hz, 0.18s @0.16` together at t=0, then the cluster `sawtooth 150→138 / 157→144 / 185→170 Hz, dur 0.5` at t=0.02 | Keeps the detuned-cluster drama but gives it a thump and a downward bend, so it lands like a strike and the run audibly dies instead of resolving into a held organ chord. The only long cue in the game; fires exactly once per run. |
| `practice-correct` | `sine 600 Hz, dur 0.08, gain 0.08` | `triangle 600 Hz, dur 0.055, gain 0.075, attack 0.001, release 0.05` | Quieter, shorter sibling of the new tick. |
| `practice-wrong` | `square 200 Hz, dur 0.2, gain 0.1` | `noise 0.03s @0.06` + `triangle 180→90 Hz, 0.14s @0.10`, both at t=0 | The strike reduced to its impact, alarm tail removed — nothing ends in practice mode. Plays without overrides, so an array is safe here. |

## Service worker

`sw.js` `CACHE_NAME` bumped `pi-game-v4` → `pi-game-v5` so the new `index.html` reaches installed clients.

## Deviations from the spec

- **`correct` is 0.07s, not the drafted 0.09s.** A recital can outpace 90 ms ticks; 70 ms keeps consecutive keystrokes from overlapping.
- **`wrong`'s thump is a pitch-dropping triangle, not the drafted noise burst alone.** The SDK's `noise` voice is white noise, which reads as hiss/crash rather than impact; a `200 → 55 Hz` triangle gives the body, with a much shorter (45 ms) noise burst kept purely as the attack edge. The saw cluster is also staggered 20 ms behind the hit so the transient reads first, and its gains drop `0.12 → 0.08/0.08/0.07` to leave headroom for the two new voices (worst-case in-phase sum ≈ 0.49).
- **The `combo` per-play gain coefficient changed (`0.05 → 0.012`), which is a play-site edit, not a cue edit.** As written, the accent peaked at gain `0.5` against a `0.14` tick — 3.5× louder than the cue it layers over, which is backwards for an accent and directly at odds with the never-fatiguing constraint. The behaviour the spec asked to preserve (single-object cue, gain scaling with the streak, capped at `min(combo, 10)`) is intact; only the coefficient moved, so the accent now runs `0.048 → 0.12` and stays under the tick at every streak level.

## Unchanged, deliberately

The in-game `state.soundEnabled` mute toggle and its behaviour, the single guarded `sfx()` wrapper, all five cue names, and the single chained registration site. No new game events. The block's comments now describe the sound identity and its constraints instead of the migration history they used to document.

## ⚠️ Not yet heard

**This audio has been designed by inspection and has not been listened to by anyone.** The numbers are informed but unverified — the `wrong` strike's voice balance and the tick's fatigue level over a long run both need a real ear pass. That is why this is a draft; please don't merge before someone plays it.

Verified by inspection: inline scripts extracted and `node --check` clean; all five cue names still match their `sfx()` call sites (`playCorrect()` and both practice-mode paths included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)