### PR TITLE
audio: graph sound pack v1 — "the memory palace"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .go.log
 .go.pid
 arcade-sdk.js
+
+# sound-pack renders — regenerable, and large
+audio/out/

--- a/audio/audition-short.js
+++ b/audio/audition-short.js
@@ -1,0 +1,88 @@
+// pi-game — the short audition. THE one to listen to first.
+//
+//   node ../paulgibeault.github.io/tools/soundpack/render.mjs \
+//     --config soundpack.config.json --audition short
+//
+// A listening file, not a diagnostic one: every sound once, in the order a
+// player meets it, then the thing the whole design stands on (the corridor
+// opening up as you go deeper), then a real run at real pace.
+//
+// v1 is a redesign, not a retune — there is no prior graph version to A/B
+// against, and the chiptune profile it replaces is a different instrument
+// rather than a worse setting of this one. So there are no OLD-vs-NEW
+// sections here. The long diagnostic timeline gets written after this file
+// has had its first ear pass, so that it proves whatever actually needed
+// proving.
+//
+(function (global) {
+  'use strict';
+  const A = global.ArcadeAudition;
+
+  const GAP = 1.15;   // roomy: each sound needs to arrive alone
+  const TAIL = 2.0;   // this room has a real tail and it must be allowed to end
+
+  // A correct keystroke at a given depth, with the streak's answer over it
+  // when the player is on one — the two cues the game fires together.
+  const key = (ctx, bus, at, r, depth, streak) => {
+    A.fire(ctx, bus, 'correct', at, r, { depth });
+    if (streak != null) A.fire(ctx, bus, 'combo', at, r, { streak });
+  };
+
+  const SECTIONS = [
+    {
+      title: 'A · The three sounds',
+      note: 'Each once, in the order you meet them. A correct digit is one footfall in a stone corridor — a contact, a little body, and the room answering behind it. A hot streak adds a SECOND footfall a beat later, offstage and darker: someone keeping pace with you, not a reward. Wrong is the step landing on nothing — the floor gives, the step swells into empty air, the corridor answers all at once, and then the run is over. Listen for what the wrong ISN\'T: no alarm, no chord, nothing loud. The punishment is the silence after it.',
+      items: [
+        A.play('correct', { label: 'a correct digit, early in a run — one step, one close return', params: { depth: 0.0 }, dur: 1.0 }),
+        A.play('correct', { label: 'a correct digit, deep in a run — the same step, more corridor', params: { depth: 1.0 }, dur: 1.8 }),
+        A.play('combo', { label: 'the streak\'s answer alone — the second footfall, offstage', params: { streak: 0.8 }, dur: 1.0 }),
+        A.custom('a correct digit ON a streak — the two together, as they fire', 1.8,
+          (ctx, bus, t, r) => key(ctx, bus, t, r, 0.55, 0.8)),
+        A.play('wrong', { label: 'WRONG — the floor gives, the step finds nothing, the corridor answers' }),
+      ],
+    },
+    {
+      title: 'B · Depth — larger, never louder',
+      note: 'The same cue at five depths, evenly spaced from the first digit to the four-hundredth. This is the entire progress meter and it is the one thing that has to be right: the direct step is IDENTICAL every time — same gain, same pitch, same length — and only the returns behind it change, growing from one close reflection to four running away down the corridor. If any of these five reads as louder rather than as bigger, the design has failed, whatever else it does. Nothing here is pitched: the archived chiptune profile climbed 440 → 1200 Hz across a run and that is precisely what this replaces.',
+      items: [
+        A.play('correct', { label: 'digit 1 — a small room', params: { depth: 0.0 }, dur: 1.0 }),
+        A.play('correct', { label: 'digit 60', params: { depth: 0.25 }, dur: 1.3 }),
+        A.play('correct', { label: 'digit 150', params: { depth: 0.5 }, dur: 1.5 }),
+        A.play('correct', { label: 'digit 280', params: { depth: 0.75 }, dur: 1.7 }),
+        A.play('correct', { label: 'digit 400 — a long way in', params: { depth: 1.0 }, dur: 2.0 }),
+        A.custom('all five back to back — the run in eight seconds', 8.0, (ctx, bus, t, r) => {
+          [0.0, 0.25, 0.5, 0.75, 1.0].forEach((d, i) => A.fire(ctx, bus, 'correct', t + i * 1.5, r, { depth: d }));
+        }),
+      ],
+    },
+    {
+      title: 'C · One run',
+      note: 'A real recitation. It opens at thinking pace on the first few digits, settles into rhythm, picks up into a streak around digit 150 where the answering step comes in, runs fast and deep — and then a wrong digit, and it stops. Listen at game density for the two failures that only show up in a run: whether the step wanders in level (it must not), and whether the returns at depth start smearing into the next keystroke when the typing gets fast. The last scene is the same passage in practice mode, where the corridor is gone entirely.',
+      items: [
+        A.custom('the opening — thinking pace, digit 1 onward, no corridor yet', 5.4, (ctx, bus, t, r) => {
+          [0.0, 0.85, 1.6, 2.2, 3.3, 3.9, 4.4].forEach((at, i) => key(ctx, bus, t + at, r, 0.01 + i * 0.004, null));
+        }),
+        A.custom('in rhythm — around digit 90, the room starting to open', 4.6, (ctx, bus, t, r) => {
+          for (let i = 0; i < 13; i++) key(ctx, bus, t + i * 0.30, r, 0.20 + i * 0.004, null);
+        }),
+        A.custom('a streak — around digit 180, fast, the second step answering', 4.6, (ctx, bus, t, r) => {
+          for (let i = 0; i < 18; i++) key(ctx, bus, t + i * 0.215, r, 0.45 + i * 0.004, Math.min(1, 0.2 + i * 0.06));
+        }),
+        A.custom('deep and quick — around digit 330, four a second', 3.6, (ctx, bus, t, r) => {
+          for (let i = 0; i < 14; i++) key(ctx, bus, t + i * 0.185, r, 0.80 + i * 0.003, 0.9);
+        }),
+        A.custom('…and the floor isn\'t there', 6.0, (ctx, bus, t, r) => {
+          for (let i = 0; i < 5; i++) key(ctx, bus, t + i * 0.20, r, 0.86, 0.9);
+          A.fire(ctx, bus, 'wrong', t + 1.10, r);
+        }),
+        A.custom('practice mode — the same passage, lights on, nothing at stake', 5.2, (ctx, bus, t, r) => {
+          for (let i = 0; i < 12; i++) A.fire(ctx, bus, 'practice-correct', t + i * 0.26, r);
+          A.fire(ctx, bus, 'practice-wrong', t + 3.30, r);
+          for (let i = 0; i < 5; i++) A.fire(ctx, bus, 'practice-correct', t + 3.90 + i * 0.26, r);
+        }),
+      ],
+    },
+  ];
+
+  A.publish({ gap: GAP, tail: TAIL, sections: SECTIONS });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/index.html
+++ b/index.html
@@ -3,6 +3,15 @@
 <head>
 <script src="/arcade-sdk.js"></script>
 <script>Arcade.init({ gameId: 'pi-game' });</script>
+<!-- Sound. The element library is the SDK's optional audio companion, taken
+     from the EVERGREEN path to match the evergreen /arcade-sdk.js above — the
+     two have to move majors together, and the rest of the fleet pins both to
+     /sdk/v3/ instead. Off the launcher origin this simply 404s and js/audio.js
+     falls back to the archived chiptune profile, which is why it loads before
+     the pack rather than being required by it. -->
+<script src="/arcade-audio.js"></script>
+<script src="js/soundpack.js"></script>
+<script src="js/audio.js"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>Pi Game</title>
@@ -984,72 +993,25 @@ const sessionTimer = Arcade.session.start({ persistKey: 'elapsedMs' });
 sessionTimer.pause();
 
 // ===== Audio =====
-// SFX are managed by Arcade.audio (SDK 3.5.0). The SDK owns the AudioContext,
-// first-gesture unlock, master gain wired to the launcher audioVolume (incl.
-// the global mute button), and suspend-on-hide / resume-on-return — so none of
-// that lives here anymore. This game keeps only its own in-game mute toggle
-// (state.soundEnabled) as an extra gate; volume itself is launcher-owned.
+// SFX are managed by Arcade.audio. The SDK owns the AudioContext, first-gesture
+// unlock, master gain wired to the launcher audioVolume (incl. the global mute
+// button), and suspend-on-hide / resume-on-return — so none of that lives here.
+// This game keeps only its own on-screen sound toggle (state.soundEnabled) as
+// an extra gate on top; volume itself is launcher-owned.
 //
-// Sound identity: a recital under pressure. 'correct' is a metronome tick that
-// keeps time *under* the player's concentration, never a reward chime; 'wrong'
-// is an alarm strike that ends the run. Everything else is a sibling of one of
-// those two. The game asks for hundreds of keystrokes in a row, so the tick's
-// first duty is to stay out of the way — unobtrusive beats interesting.
-if (window.Arcade && Arcade.audio) {
-  Arcade.audio
-    // Correct digit — the metronome tick. Triangle (a touch more edge than a
-    // sine, so it reads as a click rather than a beep), near-instant attack and
-    // a 70 ms fall to silence: percussive, and short enough that fast typing
-    // never smears one tick into the next. Stays a SINGLE-object spec because
-    // playCorrect() overrides `freq` per play for the rising digit-index ladder
-    // (Math.min(440 + idx*8, 1200)) and the SDK only merges overrides onto
-    // single-object cues — an array would silently drop the ladder. For the
-    // same reason there is no `toFreq` bend: a fixed target would mean a
-    // different-sized bend at every rung of the ladder.
-    .cue('correct', { type: 'triangle', freq: 440, dur: 0.07, gain: 0.14, attack: 0.001, release: 0.065 })
-    // Hot-streak accent layered over 'correct' (comboLevel > 3): a clean sine
-    // ping a fifth above the tick, decaying the whole way out. Also single-
-    // object — playCorrect() overrides both `freq` and `gain` per play, so it
-    // scales with the streak. It is an accent on the tick, not a second cue:
-    // it must stay quieter than the tick it rides on at every streak level.
-    .cue('combo', { type: 'sine', freq: 660, dur: 0.09, gain: 0.05, attack: 0.001, release: 0.085 })
-    // Wrong digit / game over — the alarm strike. A noise transient and a
-    // pitch-dropping triangle land together as the hit; 20 ms later the detuned
-    // sawtooth cluster sags in and holds, all three voices bending downward so
-    // the run audibly dies instead of resolving into an organ chord. The only
-    // long cue in the game, and it fires exactly once per run.
-    .cue('wrong', [
-      { type: 'noise', dur: 0.045, gain: 0.10, attack: 0.001, release: 0.044, delay: 0 },
-      { type: 'triangle', freq: 200, toFreq: 55, dur: 0.18, gain: 0.16, attack: 0.001, release: 0.16, delay: 0 },
-      { type: 'sawtooth', freq: 150, toFreq: 138, dur: 0.5, gain: 0.08, attack: 0.006, release: 0.34, delay: 0.02 },
-      { type: 'sawtooth', freq: 157, toFreq: 144, dur: 0.5, gain: 0.08, attack: 0.006, release: 0.34, delay: 0 },
-      { type: 'sawtooth', freq: 185, toFreq: 170, dur: 0.5, gain: 0.07, attack: 0.006, release: 0.34, delay: 0 },
-    ])
-    // Practice mode — the same two sounds with the stakes taken out: a quieter,
-    // shorter tick, and a strike reduced to its impact with no alarm tail,
-    // because nothing ends here. Both play without overrides, so 'practice-
-    // wrong' is free to be an array.
-    .cue('practice-correct', { type: 'triangle', freq: 600, dur: 0.055, gain: 0.075, attack: 0.001, release: 0.05 })
-    .cue('practice-wrong', [
-      { type: 'noise', dur: 0.03, gain: 0.06, attack: 0.001, release: 0.029, delay: 0 },
-      { type: 'triangle', freq: 180, toFreq: 90, dur: 0.14, gain: 0.10, attack: 0.001, release: 0.12, delay: 0 },
-    ]);
-}
-// A2 wrapper — the single guarded play-site. Feature-detects Arcade.audio and
-// gates on the in-game mute toggle (state.soundEnabled).
-const sfx = (name, opts) => {
-  if (window.Arcade && Arcade.audio && state.soundEnabled) Arcade.audio.play(name, opts);
+// Registration and the sound design itself now live in js/audio.js and
+// js/soundpack.js, loaded in <head> above. Nothing about how a sound is MADE
+// belongs in this file any more — see js/soundpack.js for the design and
+// audio/chiptune-archive.mjs for the profile a stale cache still hears.
+const PiAudio = window.PiGameAudio || {
+  // Standalone off the launcher origin, or a cache stale enough to be missing
+  // js/audio.js entirely: every call site keeps working and stays silent.
+  isGraphMode: function () { return false; },
+  setEnabled: function () {},
+  playCorrect: function () {}, playWrong: function () {},
+  playPracticeCorrect: function () {}, playPracticeWrong: function () {},
 };
-// The tick, pitched by how deep into Pi you are, plus the streak accent above
-// it. Both ride per-play overrides (see the single-object cues above). The
-// accent's gain grows with the streak but tops out below the tick's own 0.14,
-// so a hot streak colours the metronome rather than shouting over it.
-function playCorrect(digitIndex) {
-  const freq = Math.min(440 + digitIndex * 8, 1200);
-  sfx('correct', { freq });
-  if (comboLevel > 3) sfx('combo', { freq: freq * 1.5, gain: 0.012 * Math.min(comboLevel, 10) });
-}
-
+PiAudio.setEnabled(state.soundEnabled);
 // ===== Particles =====
 const canvas = document.getElementById('particle-canvas');
 const pctx = canvas.getContext('2d');
@@ -1198,7 +1160,7 @@ function updateSoundBtn() {
   $btnSound.innerHTML = state.soundEnabled ? '&#x1F50A;' : '&#x1F507;';
   $btnSound.classList.toggle('muted', !state.soundEnabled);
 }
-$btnSound.addEventListener('click', () => { state.soundEnabled = !state.soundEnabled; updateSoundBtn(); saveState(); });
+$btnSound.addEventListener('click', () => { state.soundEnabled = !state.soundEnabled; PiAudio.setEnabled(state.soundEnabled); updateSoundBtn(); saveState(); });
 
 // ===== Leaderboard Modal =====
 function renderLeaderboard(target) {
@@ -1276,7 +1238,7 @@ function handleDigitPress(digit, btn) {
   $numpad.classList.toggle('combo-active', comboLevel > 5);
 
   if (digit === expected) {
-    state.userSequence += digit; saveState(); renderPiDigits(); playCorrect(idx);
+    state.userSequence += digit; saveState(); renderPiDigits(); PiAudio.playCorrect(idx, comboLevel);
     btn.classList.add('correct-flash'); setTimeout(() => btn.classList.remove('correct-flash'), 200);
     if (!Arcade.settings.reducedMotion()) {
       document.body.classList.add('shake-correct'); setTimeout(() => document.body.classList.remove('shake-correct'), 150);
@@ -1291,7 +1253,7 @@ function gameOver(btn) {
   const score = state.userSequence.length; lastGameScore = score;
   const timeMs = sessionTimer.elapsedMs();
   const timeSec = (timeMs / 1000).toFixed(1);
-  sfx('wrong');
+  PiAudio.playWrong();
   if (!Arcade.settings.reducedMotion()) {
     document.body.classList.add('shake-wrong'); setTimeout(() => document.body.classList.remove('shake-wrong'), 400);
   }
@@ -1431,7 +1393,7 @@ function handlePracticePress(digit, btn) {
 
   if (digit === expected) {
     practicePos++;
-    sfx('practice-correct');
+    PiAudio.playPracticeCorrect();
     btn.classList.add('correct-flash'); setTimeout(() => btn.classList.remove('correct-flash'), 150);
     if (typeof currentVisual !== 'undefined' && currentVisual) currentVisual.feedDigit(digit, practiceRangeStart + practicePos);
     renderPractice();
@@ -1439,7 +1401,7 @@ function handlePracticePress(digit, btn) {
       $practiceProgress.textContent = 'Complete!';
     }
   } else {
-    sfx('practice-wrong');
+    PiAudio.playPracticeWrong();
     btn.classList.add('wrong-flash'); setTimeout(() => btn.classList.remove('wrong-flash'), 300);
     // Flash the current digit red briefly
     const cur = $practiceDigits.querySelector('.current');

--- a/js/audio.js
+++ b/js/audio.js
@@ -1,0 +1,218 @@
+/**
+ * audio.js — Sound for pi-game, via the launcher SDK's managed `Arcade.audio`.
+ * This is the game's single audio registration site.
+ *
+ * A plain script, not an ES module, because the game itself is one inline
+ * <script> in index.html: this runs before it and hands it a small API on
+ * `window.PiGameAudio`. The <script> order in index.html is what guarantees
+ * `Arcade.init()` and the pack registration have both already run by the time
+ * this evaluates.
+ *
+ * Two registration paths live here:
+ *
+ *   GRAPH PATH (the SDK's /arcade-audio.js companion loaded) — the real sound
+ *     design. js/soundpack.js holds the pack: a long stone corridor you are
+ *     reciting into, where a correct digit is a footfall and the ROOM is the
+ *     progress meter. That pack is rendered to an audition WAV and approved by
+ *     ear before it ships; do not retune it from here.
+ *
+ *     NO SYNTHESIS LIVES IN THIS GAME. Every gesture the pack is built from is
+ *     an element in the launcher's shared library. What belongs to pi-game is
+ *     the design — which gestures, how loud, how far away, how often — and
+ *     that is all js/soundpack.js contains.
+ *
+ *   FALLBACK PATH (older cached SDK/companion, or standalone without
+ *     /arcade-audio.js) — the archived chiptune profile, copied verbatim from
+ *     audio/chiptune-archive.mjs. It exists because a player on a stale
+ *     service-worker cache should get the old sound rather than silence; that
+ *     is an expected state, not an error, so it is not logged.
+ *
+ *     Its BODIES are frozen — that profile was tuned as a whole and should be
+ *     kept in sync with the archive rather than edited here.
+ *
+ * Both paths register the same five cue names, so every call site in the game
+ * works unchanged either way.
+ *
+ * ── the one real difference between the paths ─────────────────────────────
+ * The chiptune profile carried a run's progress in PITCH: `correct` climbed
+ * 440 → 1200 Hz on a per-play `freq` override, and the streak accent rode a
+ * per-play `gain`. The graph pack carries it in SPACE instead, and holds
+ * level still on purpose. So the two paths take different per-play params:
+ *
+ *   graph      correct { depth: 0..1 }   combo { streak: 0..1 }
+ *   chiptune   correct { freq }          combo { freq, gain }
+ *
+ * `playCorrect(digitIndex, comboLevel)` below is the only place that knows
+ * which is which — it is why the game calls one function instead of building
+ * overrides at the call site the way it used to.
+ *
+ * Conventions (fleet Arcade.audio conventions, launcher GAME_INTEGRATION.md §5):
+ *   A1 — cues are registered ONCE here at load. Audio is purely local, so no
+ *        `await Arcade.ready` is needed.
+ *   A2 — every play-site in the game goes through a wrapper below.
+ *   A3 — the launcher owns volume + the global mute button. pi-game keeps its
+ *        own on-screen sound toggle (`state.soundEnabled`), which predates the
+ *        SDK and is an EXTRA gate on top, never a second volume control; it is
+ *        pushed in here via setEnabled().
+ *   A4 — cue names are lowercase and event-shaped, unchanged from the
+ *        pre-graph profile.
+ */
+
+(function (global) {
+  "use strict";
+
+  var audio = function () {
+    return (global.Arcade && global.Arcade.audio) ? global.Arcade.audio : null;
+  };
+  var pack = function () {
+    return global.ArcadeSoundPack || null;
+  };
+
+  // pi-game's own on-screen toggle (A3). Defaults true, matching the game's
+  // initial state; index.html pushes the persisted value in at boot.
+  var enabled = true;
+
+  // ─── the play wrapper (A2) ────────────────────────────────────────────────
+  // Silent no-op when Arcade.audio is absent or the game's toggle is off (the
+  // SDK short-circuits before touching the AudioContext when the LAUNCHER has
+  // muted, so that case costs nothing either). Must never throw: this is
+  // called from the keypress path.
+  function sfx(name, opts) {
+    if (!enabled) return;
+    var a = audio();
+    if (a) a.play(name, opts);
+  }
+
+  // ─── registration ─────────────────────────────────────────────────────────
+
+  function registerPack(a, p) {
+    // One room for the whole game: the corridor the pack is set in.
+    a.room(p.ROOM);
+    Object.keys(p.CUES).forEach(function (name) {
+      a.graph(name, p.CUES[name], { send: p.SENDS[name] });
+    });
+  }
+
+  // ─── fallback: the archived chiptune profile ──────────────────────────────
+  // Copied verbatim from audio/chiptune-archive.mjs, which froze the game's
+  // pre-graph sound. Keep the cue BODIES in sync with that archive rather than
+  // editing them here — it is what a player on a stale service-worker cache
+  // hears, and it was tuned as a whole. The comments describe the chiptune
+  // voices, not the corridor the graph path now plays.
+
+  function registerSpecCues(a) {
+    // Correct digit — the metronome tick. Triangle (a touch more edge than a
+    // sine, so it reads as a click rather than a beep), near-instant attack
+    // and a 70 ms fall to silence. Stays a SINGLE-object spec because
+    // playCorrect() overrides `freq` per play for the rising digit-index
+    // ladder and the SDK only merges overrides onto single-object cues.
+    a.cue("correct", { type: "triangle", freq: 440, dur: 0.07, gain: 0.14, attack: 0.001, release: 0.065 });
+    // Hot-streak accent layered over 'correct': a clean sine ping a fifth
+    // above the tick. Also single-object — it takes both `freq` and `gain`
+    // per play, so it scales with the streak.
+    a.cue("combo", { type: "sine", freq: 660, dur: 0.09, gain: 0.05, attack: 0.001, release: 0.085 });
+    // Wrong digit / game over — the alarm strike. A noise transient and a
+    // pitch-dropping triangle land together as the hit; 20 ms later the
+    // detuned sawtooth cluster sags in and holds, all three voices bending
+    // downward so the run audibly dies instead of resolving into a chord.
+    a.cue("wrong", [
+      { type: "noise", dur: 0.045, gain: 0.10, attack: 0.001, release: 0.044, delay: 0 },
+      { type: "triangle", freq: 200, toFreq: 55, dur: 0.18, gain: 0.16, attack: 0.001, release: 0.16, delay: 0 },
+      { type: "sawtooth", freq: 150, toFreq: 138, dur: 0.5, gain: 0.08, attack: 0.006, release: 0.34, delay: 0.02 },
+      { type: "sawtooth", freq: 157, toFreq: 144, dur: 0.5, gain: 0.08, attack: 0.006, release: 0.34, delay: 0 },
+      { type: "sawtooth", freq: 185, toFreq: 170, dur: 0.5, gain: 0.07, attack: 0.006, release: 0.34, delay: 0 },
+    ]);
+    // Practice mode — the same two sounds with the stakes taken out.
+    a.cue("practice-correct", { type: "triangle", freq: 600, dur: 0.055, gain: 0.075, attack: 0.001, release: 0.05 });
+    a.cue("practice-wrong", [
+      { type: "noise", dur: 0.03, gain: 0.06, attack: 0.001, release: 0.029, delay: 0 },
+      { type: "triangle", freq: 180, toFreq: 90, dur: 0.14, gain: 0.10, attack: 0.001, release: 0.12, delay: 0 },
+    ]);
+  }
+
+  // ─── A1 — the single registration site ────────────────────────────────────
+  // The gestures and APIs the pack is built out of. A cached older SDK or
+  // element library has `graph()` and `el()` but not necessarily these, and a
+  // missing element would throw inside a cue at play time — a cue that
+  // half-plays is worse than the fallback profile, so the whole graph path is
+  // gated on the pack's actual dependencies rather than on a version number.
+  var NEEDED_ELEMENTS = [
+    "strike", "body", "thump", "creak", "rustle", "cents", "between",
+  ];
+
+  var graphMode = false;
+
+  (function registerCues() {
+    var a = audio();
+    if (!a) return;
+
+    var p = pack();
+    var el = (typeof a.el === "function") ? a.el() : null;
+    var graphable =
+      !!p &&
+      typeof a.graph === "function" &&
+      typeof a.room === "function" &&
+      el !== null &&
+      NEEDED_ELEMENTS.every(function (name) { return typeof el[name] === "function"; });
+
+    if (graphable) {
+      registerPack(a, p);
+      graphMode = true;
+    } else {
+      // Stale cached SDK, or standalone without /arcade-audio.js. Expected,
+      // not a bug — no console noise.
+      registerSpecCues(a);
+    }
+  })();
+
+  // ─── how far into the run the sound is ────────────────────────────────────
+  // The pack's corridor opens up across `depth` 0..1. Four hundred digits is
+  // the top of the scale: past it the room simply stops growing, which is the
+  // right behaviour — a run that long is already as large as the sound gets,
+  // and the alternative is a room that never stops expanding.
+  var DEPTH_DIGITS = 400;
+
+  // The streak's answering footfall fires above the same threshold the
+  // chiptune accent used (comboLevel > 3) and saturates at the same cap (10),
+  // so the two paths turn on and off at identical moments.
+  var COMBO_THRESHOLD = 3;
+  var COMBO_CAP = 10;
+
+  // Chiptune-path overrides, preserved exactly (see the archive): the tick
+  // climbs +8 Hz per digit off 440, capped at 1200; the accent sits a fifth
+  // above it at 0.012 per streak level.
+  function chiptuneFreq(digitIndex) { return Math.min(440 + digitIndex * 8, 1200); }
+
+  global.PiGameAudio = {
+    // True when the graph pack registered — for diagnostics and tests; the
+    // game itself never needs to branch on it.
+    isGraphMode: function () { return graphMode; },
+
+    // pi-game's own sound toggle (A3). index.html calls this at boot with the
+    // persisted value and again whenever the button is pressed.
+    setEnabled: function (on) { enabled = !!on; },
+
+    // A correct digit: the footfall, plus the streak's answer over it when the
+    // player is on one. The two paths want different per-play params, and this
+    // is the only place that knows the difference.
+    playCorrect: function (digitIndex, comboLevel) {
+      var streaking = comboLevel > COMBO_THRESHOLD;
+      if (graphMode) {
+        sfx("correct", { depth: Math.min(1, digitIndex / DEPTH_DIGITS) });
+        if (streaking) {
+          sfx("combo", { streak: Math.min(1, (comboLevel - COMBO_THRESHOLD) / (COMBO_CAP - COMBO_THRESHOLD)) });
+        }
+      } else {
+        var freq = chiptuneFreq(digitIndex);
+        sfx("correct", { freq: freq });
+        if (streaking) {
+          sfx("combo", { freq: freq * 1.5, gain: 0.012 * Math.min(comboLevel, COMBO_CAP) });
+        }
+      }
+    },
+
+    playWrong: function () { sfx("wrong"); },
+    playPracticeCorrect: function () { sfx("practice-correct"); },
+    playPracticeWrong: function () { sfx("practice-wrong"); },
+  };
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/soundpack.js
+++ b/js/soundpack.js
@@ -1,0 +1,253 @@
+// pi-game sound pack — the game's own sound design.
+//
+// Loaded as a plain script after /sdk/v3/arcade-audio.js. The launcher's
+// tools/soundpack renderer loads this same file to produce audition WAVs, so
+// what gets approved by ear is what plays.
+//
+// ── v1 — the memory palace ────────────────────────────────────────────────
+// You are walking a long corridor in the dark, reciting from memory. Every
+// digit is a footstep. One wrong step and the floor isn't there.
+//
+// The chiptune profile this replaces (audio/chiptune-archive.mjs) got one
+// thing exactly right and it survives unchanged: THE TICK'S FIRST DUTY IS TO
+// STAY OUT OF THE WAY. The game asks for hundreds of keystrokes in a row, so
+// interesting is a defect. What changes is what carries the run's shape.
+//
+//   DEPTH IS THE ONLY THING THAT MOVES, AND IT MOVES IN SPACE. Digit 5 is a
+//   dry footfall in a small room. Digit 200 is the SAME footfall with the
+//   corridor answering it. The archived profile climbed 440 → 1200 Hz across
+//   a run; a tone rising for four hundred keystrokes is the chiptune tell,
+//   and it is what makes long runs tiring. Pitch now holds still and the
+//   room opens up instead — which is a thing you feel without listening to
+//   it, and that is the point.
+//
+//   A REFLECTION HAS NO CONTACT CLICK. That one rule is what makes the
+//   copies read as the corridor answering rather than as more footsteps: a
+//   room eats the transient first, then the top end, then everything. Every
+//   echo in this pack is built by taking the gesture away rather than by
+//   adding a delay to it.
+//
+// Five cues, the same five the game already plays:
+//
+//   correct           a footfall, plus however much corridor you have earned
+//   combo             a second footfall answering, offstage — someone keeping pace
+//   wrong             the step lands on nothing
+//   practice-correct  the same corridor with the lights on
+//   practice-wrong    just a stop
+//
+// Register plan, so simultaneous cues occupy different bands:
+//   footfall body 150–720 · its weight 54–98 · contact 1900+
+//   the answer 150–390 · the fall 33–240 · its wash 190–1100
+//
+// LEVEL NEVER VARIES PER PLAY, at any depth or any streak. This is the one
+// rule the fleet has paid for twice (see sow-duku's pack header), and depth
+// is exactly the kind of parameter that would break it if it were allowed to
+// touch gain. It isn't: at every depth the DIRECT step has identical gain and
+// identical pitch spread, and the reflections only ever add tail behind it.
+// The run gets larger, never louder. Section D of the short audition exists
+// to prove that by ear.
+//
+// The archived chiptune profile is kept verbatim in audio/chiptune-archive.mjs
+// and is what a player on a stale service-worker cache still hears.
+
+(function (global) {
+  'use strict';
+  const S = global.ArcadeAudioElements;
+
+  // Every cue here is built from the element library's gestures, so with the
+  // library absent — a stale service-worker cache, or running standalone off
+  // the launcher origin — there is nothing registrable and the game's audio
+  // module takes its fallback path. Bail before dereferencing S: this file is
+  // a plain script, and a throw here would surface as a page error even though
+  // the fallback itself works. Also covers an OLDER library that predates
+  // registerPack, which is the same stale-cache scenario one version on.
+  if (!S || typeof S.registerPack !== 'function') return;
+
+  // Stone, and a lot of it in one direction. Longer and darker than anything
+  // else in the fleet: this room is not atmosphere, it is the progress meter,
+  // so it has to have somewhere to grow into. The high shelf is well down —
+  // a corridor absorbs the top end long before it absorbs the bottom, and
+  // without that this reads as a plate reverb rather than as masonry.
+  const ROOM = {
+    dur: 2.4,
+    decay: 0.85,
+    preDelay: 0.022,
+    wet: 0.85,
+    shelfHz: 3000,
+    shelfDb: -8,
+    seed: 3141,
+  };
+
+  // How much corridor each cue sits in. `correct` is deliberately modest —
+  // its depth comes from the reflections it builds itself, and doubling that
+  // up with a big send would wash out the very transient the ear is using to
+  // count steps. Practice is DRY: nothing is at stake there, so there is no
+  // room at all.
+  const SENDS = {
+    'correct': 0.11,
+    'combo': 0.30,
+    'wrong': 0.46,
+    'practice-correct': 0.0,
+    'practice-wrong': 0.0,
+  };
+
+  // Levels, by layer. The footfall is the quietest thing that can still be
+  // counted — it fires on literally every keystroke of every run, and it is
+  // under the player's concentration rather than in front of it. The fall is
+  // the only loud thing in the game and it happens exactly once.
+  const STEP = 0.095;      // one footfall, at any depth
+  const ANSWER = 0.052;    // the streak's answering step, always below yours
+  const DROP = 0.30;       // the floor going away
+
+  const clamp01 = (v) => (typeof v === 'number' && isFinite(v) ? Math.max(0, Math.min(1, v)) : 0);
+
+  // One footfall. `click` is the contact; a real step has one and a REFLECTION
+  // does not. `bright` scales everything above the fundamental together, so a
+  // copy further down the corridor is darker as well as quieter — the two
+  // always move together, because in a real room they do.
+  function footfall(ctx, o, t, r, p) {
+    const g = p.gain;
+    const bright = p.bright;
+    if (p.click) {
+      S.strike(ctx, o, t, {
+        dur: S.between(r, 0.0035, 0.0055), hp: 1900 * S.cents(r, 90),
+        gain: g * 0.55, seed: (r() * 1e6) | 0,
+      });
+    }
+    const f0 = (p.f0 || 176) * S.cents(r, p.spread == null ? 55 : p.spread);
+    S.body(ctx, o, t, {
+      f0: f0, gain: g,
+      partials: [
+        { ratio: 1.00, gain: 1.00, decay: S.between(r, 0.075, 0.095), detune: 5, attack: 0.003 },
+        { ratio: 2.41, gain: 0.34 * bright, decay: S.between(r, 0.040, 0.055), detune: 9, attack: 0.002 },
+        { ratio: 4.07, gain: 0.16 * bright, decay: S.between(r, 0.022, 0.030), detune: 13, attack: 0.002 },
+      ],
+    });
+    // the weight under the heel — small, and it goes away with distance too
+    S.thump(ctx, o, t + 0.002, {
+      f0: S.between(r, 88, 98), f1: S.between(r, 54, 62),
+      dur: S.between(r, 0.055, 0.070), attack: 0.006,
+      gain: g * 0.34 * bright, seed: (r() * 1e6) | 0,
+    });
+  }
+
+  const CUES = {
+    // A CORRECT DIGIT — one footfall, and however much corridor you have
+    // earned. `params.depth` is 0..1 across a run (the game maps digit index
+    // onto it); at 0 there is one close reflection and at 1 there are four,
+    // spreading further apart as they go.
+    //
+    // Everything that makes this bigger is BEHIND the direct sound: same
+    // gain, same pitch, same 90 ms of core at digit 5 and digit 500. Fast
+    // typing therefore never smears — the thing that lengthens is quiet
+    // enough to be walked over by the next step, which is exactly what
+    // happens when you walk faster in a real corridor.
+    'correct': function (ctx, o, t, params, r) {
+      const depth = clamp01(params && params.depth);
+      footfall(ctx, o, t, r, { gain: STEP, bright: 1.0, click: true });
+
+      const n = 1 + Math.round(depth * 3);
+      const spread = 0.042 + depth * 0.115;
+      const LEVEL = [0.30, 0.19, 0.125, 0.08];
+      let at = 0;
+      for (let i = 0; i < n; i++) {
+        // each return is further out than the last — a corridor's reflections
+        // are not evenly spaced, they run away from you
+        at += spread * S.between(r, 0.82, 1.24) * (1 + i * 0.45);
+        footfall(ctx, o, t + at, r, {
+          gain: STEP * LEVEL[i],
+          bright: 0.55 - i * 0.11,
+          click: false,
+          f0: 176 * (1 - i * 0.012),
+          spread: 25,
+        });
+      }
+      return 0.35 + depth * 0.9;
+    },
+
+    // A HOT STREAK — a second footfall answering, a little way off. Not a
+    // ping above the tick (the archived profile's choice, and the reason a
+    // streak used to read as a reward rather than as company): the same
+    // material as your own step, later, lower and darker, so it fuses with
+    // the step instead of sitting on top of it.
+    //
+    // `params.streak` is 0..1. It buys CLARITY — the answer rings longer and
+    // holds its second partial — and never level. A streak you can hear
+    // getting louder is a streak that punishes you for having one.
+    'combo': function (ctx, o, t, params, r) {
+      const streak = clamp01(params && params.streak);
+      const f0 = S.between(r, 150, 162);
+      S.body(ctx, o, t + S.between(r, 0.085, 0.125), {
+        f0: f0, gain: ANSWER,
+        partials: [
+          { ratio: 1.00, gain: 1.00, decay: 0.085 + streak * 0.075, detune: 6, attack: 0.004 },
+          { ratio: 2.41, gain: 0.18 + streak * 0.22, decay: 0.038 + streak * 0.030, detune: 10, attack: 0.003 },
+        ],
+      });
+      return 0.5;
+    },
+
+    // A WRONG DIGIT — the step lands on nothing, and the run is over. Three
+    // things in order, and none of them is an alarm:
+    //
+    //   1. the floor gives — stick-slip, which is what a thing about to break
+    //      actually does, and the only warning you get
+    //   2. the step, arriving as a SWELL rather than a punch. The attack is
+    //      well off the floor on purpose: a fast onset here is heard as an
+    //      impact, and an impact is a thing hitting something, which is the
+    //      one reading this must not have
+    //   3. the corridor answering all at once — a wash of air falling away,
+    //      sent hard into the room, and then nothing
+    //
+    // The archived profile ended the run with a detuned sawtooth cluster
+    // sagging under a noise transient. It was unmistakable and it was also
+    // the loudest thing in the game by a distance, which made losing feel
+    // like being told off. The punishment here is the silence afterwards.
+    'wrong': function (ctx, o, t, params, r) {
+      S.creak(ctx, o, t, {
+        f0: S.between(r, 320, 380), f1: S.between(r, 120, 145), Q: 6,
+        lp: 900, dur: S.between(r, 0.16, 0.20), rate: 1.6, rate1: 0.5,
+        gain: DROP * 0.30, attack: 0.02, seed: (r() * 1e6) | 0,
+      });
+      S.thump(ctx, o, t + S.between(r, 0.15, 0.19), {
+        f0: S.between(r, 74, 84), f1: S.between(r, 33, 39),
+        dur: S.between(r, 0.55, 0.65), attack: 0.045,
+        gain: DROP, seed: (r() * 1e6) | 0,
+      });
+      S.rustle(ctx, o, t + S.between(r, 0.16, 0.21), {
+        f0: S.between(r, 900, 1100), f1: S.between(r, 190, 240), Q: 0.8,
+        lp: 1600, dur: S.between(r, 0.70, 0.85),
+        gain: DROP * 0.20, attack: 0.05, seed: (r() * 1e6) | 0,
+      });
+      return 2.4;
+    },
+
+    // PRACTICE, CORRECT — the same corridor with the lights on. Identical
+    // footfall, and no reflections at any depth (practice ignores `depth`
+    // entirely) on top of a send of zero. Nothing is at stake, so there is
+    // no room: the sound tells you where you are without you having to think
+    // about it, which is the whole difference between the two modes.
+    'practice-correct': function (ctx, o, t, params, r) {
+      footfall(ctx, o, t, r, { gain: STEP, bright: 0.85, click: true });
+      return 0.25;
+    },
+
+    // PRACTICE, WRONG — just a stop. The step that lands on nothing, with
+    // the floor's warning and the corridor's answer both taken away, because
+    // nothing ends here. Short enough to be walked straight over by the next
+    // attempt.
+    'practice-wrong': function (ctx, o, t, params, r) {
+      S.thump(ctx, o, t, {
+        f0: S.between(r, 78, 88), f1: S.between(r, 40, 46),
+        dur: S.between(r, 0.16, 0.20), attack: 0.020,
+        gain: DROP * 0.42, seed: (r() * 1e6) | 0,
+      });
+      return 0.4;
+    },
+  };
+
+  // Published under the framework's well-known handle (arcade-audio.js
+  // registerPack) so the game's audio module and the launcher's soundpack
+  // toolchain both reach it without either side knowing this game's name.
+  S.registerPack({ name: 'pi-game', ROOM, SENDS, CUES });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/pi-game.md
+++ b/pi-game.md
@@ -42,9 +42,10 @@ The user must be able to select from 4 distinct themes on the start screen. Impl
 The core loop is simple, so the feedback must be highly engaging. Implement the following dynamically via JavaScript/CSS based on the active theme:
 
 * **Visuals:** Add subtle CSS keyframe screen shakes on correct presses, and a violent screen shake on failure. Add particle bursts or CSS transition flares on the number pad when a key is pressed.
-* **Audio:** Procedural UI sounds via the launcher's managed `Arcade.audio` SFX engine (SDK 3.5.0+) — not hand-rolled Web Audio API code in-game; see `index.html`'s `Arcade.audio.cue(...)` registrations.
-* Correct press: A synthesized tone that slightly increases in pitch (`frequency`) with every consecutive correct digit.
-* Wrong press: A harsh, dissonant chord or low-frequency drop.
+* **Audio:** Procedural sound via the launcher's managed `Arcade.audio` — not hand-rolled Web Audio API code in-game. Registration lives in `js/audio.js`; the design lives in `js/soundpack.js` and is approved by ear from a rendered audition before it ships.
+* Correct press: A footfall in a long stone corridor. What grows across a run is the ROOM — reflections behind the step, driven by how deep into Pi you are — not the pitch and not the level.
+* Wrong press: The step lands on nothing. The floor gives, the step swells into empty air, the corridor answers at once, and the run is over.
+* *(Superseded: the original brief asked for a tone rising in pitch per digit and a dissonant chord on failure. That is the chiptune profile, frozen in `audio/chiptune-archive.mjs`, and it is still what a player on a stale service-worker cache hears.)*
 
 
 * **Combo Modifiers:** If the time between keypresses is very short, intensify the visual glow or particles to reward speed and muscle memory.

--- a/soundpack.config.json
+++ b/soundpack.config.json
@@ -1,0 +1,9 @@
+{
+  "name": "pi-game",
+  "pack": "js/soundpack.js",
+  "auditions": {
+    "short": "audio/audition-short.js"
+  },
+  "out": "audio/out",
+  "sampleRate": 48000
+}

--- a/sw.js
+++ b/sw.js
@@ -1,12 +1,20 @@
 // Pi Game — Service Worker
 // Caches all assets for offline play after first load.
 
-const CACHE_NAME = 'pi-game-v5';
+// v6: the graph sound pack — js/soundpack.js and js/audio.js ship for the
+// first time, and index.html changed to load them. Both are same-origin, so
+// they belong in ASSETS; the element library they depend on
+// (/arcade-audio.js) is launcher-owned and cross-origin, and is deliberately
+// NOT listed — when it is unavailable js/audio.js falls back to the archived
+// chiptune profile, which is exactly the behaviour offline should have.
+const CACHE_NAME = 'pi-game-v6';
 const ASSETS = [
   './',
   './index.html',
   './manifest.json',
   './icon.svg',
+  './js/soundpack.js',
+  './js/audio.js',
   './visuals/tracer.js?v=2',
   './visuals/spirograph.js?v=2',
   './visuals/gallery.js?v=4',


### PR DESCRIPTION
## What

Replaces the chiptune profile with a graph pack: a long stone corridor you recite into. Every correct digit is a footfall; **the room is the progress meter** — reflections grow behind the step as you go deeper into Pi, while the direct step holds identical pitch and level at every depth. The archived profile's 440→1200 Hz ladder is gone. A streak is a second footfall answering offstage; wrong is the step landing on nothing, and the punishment is the silence after it; practice is the same corridor with the lights on (fully dry).

- `js/soundpack.js` — the design (5 cues, one room). Rendered to an audition WAV by the launcher's `tools/soundpack` renderer, so what gets ear-approved is what plays.
- `js/audio.js` — single registration site. Graph path gated on the pack's actual element dependencies; falls back to the frozen chiptune profile (`audio/chiptune-archive.mjs`) on a stale cache or standalone. `playCorrect(digitIndex, comboLevel)` is the only place that knows the two paths take different per-play params.
- `audio/audition-short.js` + `soundpack.config.json` — the listening cut (delivered for ear pass 2026-07-28).
- `index.html` — loads the companion + pack + audio module; call sites now go through `PiGameAudio`.
- `sw.js` — v5→v6, precaches the two new files. `/arcade-audio.js` deliberately not precached: offline correctly gets the fallback.

## Verification

- Staged via the launcher's `dev.sh`: registers in **graph mode** (gate predicate checked directly), all `NEEDED_ELEMENTS` present, every cue fires without throwing at depths 0→1 with streak, zero console errors.
- Render analysis: depth ladder flat at −15.8/−16.0/−15.7/−16.1/−15.9 dBFS across five depths while the room tail grows −39 → −25 dB — larger, never louder.
- Renders under the launcher's fixed renderer (t=0 lead-in, paulgibeault/paulgibeault.github.io#109).

Part of paulgibeault/paulgibeault.github.io#107. Ear pass pending; long diagnostic audition follows the first pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)