### PR TITLE
fix: canonical service worker — stop deleting the rest of the arcade's caches

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write # version_bump pushes the bump commit back to main
   pages: write
   id-token: write
 
@@ -22,3 +22,8 @@ concurrency:
 jobs:
   fleet:
     uses: paulgibeault/paulgibeault.github.io/.github/workflows/fleet-ci.yml@main
+    with:
+      # sw.js derives its cache name from APP_VERSION, which this step
+      # rewrites — without it the cache identity freezes and returning
+      # players never execute a deployed fix.
+      version_bump: true

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,31 @@
-// Pi Game — Service Worker
-// Caches all assets for offline play after first load.
+/* Pi Game Service Worker — offline-first cache.
+ *
+ * CANONICAL FLEET SHAPE. The structure here — version line, owned-prefix
+ * cleanup, scope-guarded fetch, skip-waiting message — is meant to be
+ * identical across every arcade app; only APP_VERSION, CACHE_PREFIX and the
+ * precache list differ. Fix a bug here and it has to be carried everywhere.
+ */
 
-const CACHE_NAME = 'pi-game-v7';
+// Written by fleet CI on every deploy (fleet-ci.yml, "Bump patch version").
+// DO NOT EDIT BY HAND — a hand-maintained constant drifts, and when it drifts
+// the origin serves a fix that no returning player ever executes. That is not
+// hypothetical: it stranded a sibling game's players for two releases.
+//
+// Tracks the app version now, so it moves on every deploy. The old private
+// v7 counter is abandoned deliberately: only string inequality matters for
+// cache identity, so any change to this line invalidates correctly.
+const APP_VERSION = '1.0.0';
+
+// Every cache this game has ever owned starts with this prefix — including the
+// old hand-numbered 'pi-game-v7' names, so the switch to a version-derived
+// name still collects them. Cleanup is filtered to it; see activate for why
+// that is not optional.
+const CACHE_PREFIX = 'pi-game-';
+const CACHE_NAME = `${CACHE_PREFIX}v${APP_VERSION}`;
+
+// WARNING: This list is manually maintained. When adding new static assets
+// (JS files, CSS files, images, sounds, etc.), update this list too or
+// offline mode will silently break for those assets.
 const ASSETS = [
   './',
   './index.html',
@@ -18,19 +42,47 @@ self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
   );
-  self.skipWaiting();
+  // Deliberately NOT skipWaiting(). The new worker installs and waits; the
+  // launcher spots it and offers the player an explicit "update ready" reload,
+  // then sends the message below once they accept. Activating unannounced
+  // would swap the cache under a running game, so anything fetched lazily
+  // after the swap would come from a different build than the code asking.
+});
+
+self.addEventListener('message', event => {
+  // Sent by the launcher's update control (menu → "Check for Updates", or the
+  // automatic prompt) once the player accepts the reload.
+  if (event.data && event.data.type === 'arcade:sw.skipWaiting') self.skipWaiting();
 });
 
 self.addEventListener('activate', event => {
   event.waitUntil(
     caches.keys().then(keys =>
-      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+      Promise.all(
+        keys
+          // ONLY our own caches. caches.keys() is ORIGIN-scoped and the whole
+          // fleet shares paulgibeault.github.io, so the bare `k !== CACHE_NAME`
+          // filter this used to have deleted the launcher's cache and every
+          // sibling game's on each activation — every app silently destroying
+          // every other app's offline support, on every deploy.
+          .filter(k => k.startsWith(CACHE_PREFIX) && k !== CACHE_NAME)
+          .map(k => caches.delete(k))
+      )
     )
   );
   self.clients.claim();
 });
 
 self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+
+  // Only requests within this game's own scope. Without this guard the
+  // handler below caches EVERY request the page makes under our cache —
+  // including launcher assets like /arcade-sdk.js, which then get served
+  // stale from here indefinitely, and cross-origin responses we have no
+  // business storing.
+  if (!event.request.url.startsWith(self.registration.scope)) return;
+
   if (event.request.mode === 'navigate') {
     // Network-first for the HTML shell to prevent stale content
     event.respondWith(

--- a/tests/service-worker.test.js
+++ b/tests/service-worker.test.js
@@ -1,0 +1,177 @@
+/**
+ * service-worker.test.js — the sw.js invariants that have each already cost
+ * the fleet a production incident or come one step from it.
+ *
+ * 1. Cleanup is scoped to our own caches. `caches.keys()` is ORIGIN-scoped and
+ *    the whole fleet shares paulgibeault.github.io, so the obvious
+ *    `k !== CACHE_NAME` filter deletes the launcher's cache and every sibling
+ *    game's on every activation. This worker shipped that filter, and was the
+ *    last one on the origin still doing it.
+ *
+ * 2. The cache identity keeps the shape fleet CI rewrites, and derives from
+ *    it. If that line stops matching CI's sed, the rewrite silently stops
+ *    firing and every returning player is stranded on a stale cache.
+ *
+ * 3. install() does not skipWaiting. The launcher's update flow depends on the
+ *    new worker WAITING so the player can be offered a reload; a worker that
+ *    activates unannounced swaps the cache under a running game.
+ *
+ * 4. fetch() only answers for our own scope. Without that guard this worker
+ *    caches launcher assets (arcade-sdk.js) under our cache and serves them
+ *    stale to the whole app indefinitely.
+ *
+ * The worker is evaluated in a vm with a fake ServiceWorkerGlobalScope rather
+ * than mocked, so the assertions run the real handler bodies.
+ */
+
+import assert from 'node:assert';
+import test from 'node:test';
+import vm from 'node:vm';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SW_SRC = readFileSync(join(ROOT, 'sw.js'), 'utf8');
+const PKG = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')); // realistic cache keys
+const SCOPE = 'https://paulgibeault.github.io/pi-game/';
+
+/** Evaluate sw.js against a fake global scope and return the handles. */
+function loadWorker({ cacheKeys = [] } = {}) {
+  const deleted = [];
+  const handlers = {};
+  const calls = { skipWaiting: 0, claim: 0, addAll: null };
+
+  const caches = {
+    keys: async () => cacheKeys.slice(),
+    delete: async (k) => { deleted.push(k); return true; },
+    open: async () => ({
+      addAll: async (list) => { calls.addAll = list; },
+      put: async () => {},
+    }),
+    match: async () => undefined,
+  };
+
+  const self = {
+    addEventListener: (type, fn) => { handlers[type] = fn; },
+    skipWaiting: () => { calls.skipWaiting++; },
+    clients: { claim: () => { calls.claim++; } },
+    registration: { scope: SCOPE },
+    location: { hostname: 'paulgibeault.github.io' },
+    caches,
+  };
+
+  // The fetch handler falls through to the network on a cache miss, so the
+  // scope test would otherwise reach a real fetch that does not exist here.
+  const fetchStub = async () => ({ ok: false, clone: () => ({}) });
+  const ctx = vm.createContext({ self, caches, console, fetch: fetchStub });
+  vm.runInContext(SW_SRC, ctx);
+
+  const fire = async (type, data) => {
+    assert.ok(handlers[type], `sw.js registered no '${type}' handler`);
+    let waited = null;
+    await handlers[type]({ ...data, waitUntil: (p) => { waited = p; } });
+    if (waited) await waited;
+  };
+
+  /** Drive the fetch handler; returns true if the worker took the request. */
+  const fetchHandled = (url, { method = 'GET', mode = 'no-cors' } = {}) => {
+    let responded = false;
+    handlers.fetch({
+      request: { url, method, mode, clone: () => ({}) },
+      respondWith: () => { responded = true; },
+    });
+    return responded;
+  };
+
+  return { fire, fetchHandled, deleted, calls, ctx };
+}
+
+test('activate deletes only this game\'s caches, never a sibling\'s', async () => {
+  const w = loadWorker({
+    cacheKeys: [
+      'paul-arcade-v67',           // launcher — must survive
+      'hecknsic-v1.2.28',          // sibling — must survive
+      'sowduku-shell-v10',         // sibling — must survive
+      'pi-game-v7',                // ours, legacy hand-numbered — must go
+      `pi-game-v${PKG.version}`,   // ours, current — must stay
+    ],
+  });
+
+  await w.fire('activate');
+
+  assert.deepStrictEqual(
+    w.deleted, ['pi-game-v7'],
+    'activate must delete exactly our own stale caches — deleting anything ' +
+    'else destroys another app\'s offline support, and keeping our own stale ' +
+    'one is what serves players a fix they never execute');
+  assert.strictEqual(w.calls.claim, 1, 'activate should claim clients');
+});
+
+test('the cache identity is in the shape CI rewrites, and derives from it', () => {
+  // Deliberately a SHAPE check, not `APP_VERSION === PKG.version`. CI writes
+  // both in one commit so they match on main, but any PR open across a deploy
+  // merges a newer package.json onto an older sw.js — equality would fail on
+  // branch staleness, which says nothing about whether the app is correct.
+  const declared = /^const APP_VERSION = '([^']*)';$/m.exec(SW_SRC);
+  assert.ok(
+    declared,
+    "sw.js must declare `const APP_VERSION = '…';` at the start of a line, " +
+    'single-quoted — that exact shape is what fleet-ci.yml rewrites on deploy');
+  assert.match(
+    declared[1], /^\d+\.\d+\.\d+$/,
+    `APP_VERSION should be a bare semver (got '${declared[1]}')`);
+
+  assert.match(
+    SW_SRC, /^const CACHE_NAME = `\$\{CACHE_PREFIX\}v\$\{APP_VERSION\}`;$/m,
+    'CACHE_NAME must interpolate CACHE_PREFIX and APP_VERSION, not hardcode ' +
+    'a literal — otherwise bumping the version leaves the cache identity ' +
+    'unchanged and no update ever fires');
+});
+
+test('install precaches and does NOT skipWaiting', async () => {
+  const w = loadWorker();
+  await w.fire('install');
+
+  assert.ok(w.calls.addAll && w.calls.addAll.length > 0, 'install should precache assets');
+  assert.ok(
+    w.calls.addAll.includes('./index.html'),
+    'the precache list should cover the app shell');
+  assert.strictEqual(
+    w.calls.skipWaiting, 0,
+    'install must not skipWaiting — the launcher\'s update prompt depends on ' +
+    'the new worker waiting, and activating unannounced swaps the cache under ' +
+    'a running game');
+});
+
+test('the launcher can activate a waiting worker on demand', async () => {
+  const w = loadWorker();
+  await w.fire('message', { data: { type: 'arcade:sw.skipWaiting' } });
+  assert.strictEqual(w.calls.skipWaiting, 1, 'the update control must be able to activate the waiting worker');
+
+  const ignored = loadWorker();
+  await ignored.fire('message', { data: { type: 'something-else' } });
+  assert.strictEqual(ignored.calls.skipWaiting, 0, 'unrelated messages must not activate the worker');
+});
+
+test('fetch answers only for our own scope', () => {
+  const w = loadWorker();
+
+  assert.strictEqual(
+    w.fetchHandled(SCOPE + 'visuals/tracer.js'), true,
+    'our own assets must be served from the cache');
+
+  assert.strictEqual(
+    w.fetchHandled('https://paulgibeault.github.io/arcade-sdk.js'), false,
+    'a launcher asset must fall through — caching it here serves the whole ' +
+    'app a stale SDK from this game\'s cache indefinitely');
+  assert.strictEqual(
+    w.fetchHandled('https://paulgibeault.github.io/hecknsic/js/main.js'), false,
+    'a sibling game\'s asset must fall through');
+  assert.strictEqual(
+    w.fetchHandled('https://example.com/thing.js'), false,
+    'cross-origin requests must fall through');
+  assert.strictEqual(
+    w.fetchHandled(SCOPE + 'api', { method: 'POST' }), false,
+    'non-GET requests must fall through');
+});


### PR DESCRIPTION
Pi Game was the **last worker still live on the shared origin** with the cross-game cache bug.

## The bug

```js
keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
```

`caches.keys()` is **origin-scoped**, and the whole fleet lives on `paulgibeault.github.io`. So every Pi Game activation deleted the launcher's cache and every sibling game's — silently wiping the entire arcade's offline support. The launcher and HecknSic did the same thing back.

Cleanup is now filtered to `CACHE_PREFIX`, which still matches the old hand-numbered `pi-game-v7` name so it gets collected rather than orphaned forever.

## Three more, from the canonical shape

**`APP_VERSION` is CI-owned.** `pages.yml` opts into `version_bump` (and `contents: write`), and `CACHE_NAME` derives from it. The private `v7` counter is abandoned deliberately — only string inequality matters for cache identity, so `v7 → v1.0.0` still invalidates correctly.

**`install()` no longer `skipWaiting()`s.** The worker waits so the launcher's update control can offer the player a reload. This is what makes cache-first safe: without a recovery path a bad deploy strands players permanently. Paired with the `arcade:sw.skipWaiting` message handler the launcher sends once the player accepts.

**`fetch()` is scope-guarded and GET-only.** It had *no* guard — the handler answered for every request the page made, so launcher assets like `/arcade-sdk.js` got cached under this game's cache and served stale to the whole app indefinitely, and cross-origin responses were stored too.

## Verification

`tests/service-worker.test.js` evaluates the real `sw.js` in a `vm` against a fake `ServiceWorkerGlobalScope`, so the assertions run the actual handler bodies rather than a mock.

**All five tests fail against the old worker** (checked by stashing the new one):

```
✖ activate deletes only this game's caches, never a sibling's
✖ the cache identity is in the shape CI rewrites, and derives from it
✖ install precaches and does NOT skipWaiting
✖ the launcher can activate a waiting worker on demand
✖ fetch answers only for our own scope
```

Full suite green: 7 passed, 0 failed.

The version assertion is deliberately a **shape** check, not `APP_VERSION === package.json version` — equality false-fails on any PR left open across a deploy, since main auto-bumps underneath the branch. The shape is the real invariant: if the line stops matching CI's `sed`, the rewrite silently stops firing.

## Sequencing

Depends on [launcher #116](https://github.com/paulgibeault/paulgibeault.github.io/pull/116) for the update UX. Until that lands, a new worker here waits for all clients to close before activating — normal SW behaviour, slightly slower propagation, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)