### PR TITLE
Generated SW precache; Arcade.loop for the particle/visual loop

### DIFF
--- a/index.html
+++ b/index.html
@@ -1089,21 +1089,20 @@ function spawnErrorParticles(x, y) {
 
 /* Embedded visual classes replaced by modular scripts */
 
-let animationFrameId = null;
-function animateParticles() {
+// The SDK owns the frame loop: Arcade.loop cancels on suspend and re-arms on
+// resume, so this file no longer wires that by hand. It also parks itself when
+// there is nothing moving — start() and stop() are the idle flag.
+const animLoop = Arcade.loop(() => {
   pctx.clearRect(0, 0, canvas.width, canvas.height);
   particles = particles.filter(p => p.life > 0);
   particles.forEach(p => { p.update(); p.draw(pctx); }); pctx.globalAlpha = 1;
   const bendyActive = currentVisual ? currentVisual.update() : false;
   if (currentVisual) currentVisual.draw(pctx);
-  if (particles.length > 0 || bendyActive) {
-    animationFrameId = requestAnimationFrame(animateParticles);
-  } else {
-    animationFrameId = null;
-  }
-}
+  if (particles.length === 0 && !bendyActive) animLoop.stop();
+});
 function ensureAnimationLoop() {
-  if (!animationFrameId) animationFrameId = requestAnimationFrame(animateParticles);
+  // start() is idempotent — it never stacks a second frame request.
+  animLoop.start();
 }
 
 function triggerParticles(el, color) {
@@ -1519,11 +1518,11 @@ $retryBtn.addEventListener('click', () => { state.gameState = 'MENU'; saveState(
 // ===== Lifecycle (launcher iframe pool) =====
 Arcade.onSuspend(() => {
   stopTimer();
-  if (animationFrameId) { cancelAnimationFrame(animationFrameId); animationFrameId = null; }
+  // The frame loop is not cancelled here — Arcade.loop already parks itself on
+  // suspend and re-arms on resume if it was running.
 });
 Arcade.onResume(() => {
   if (state.gameState === 'PLAYING' && state.userSequence.length > 0) startTimer();
-  ensureAnimationLoop();
 });
 
 // Launcher imported a save while we were running — re-hydrate from disk.

--- a/sw.js
+++ b/sw.js
@@ -26,21 +26,30 @@ const CACHE_NAME = `${CACHE_PREFIX}v${APP_VERSION}`;
 // WARNING: This list is manually maintained. When adding new static assets
 // (JS files, CSS files, images, sounds, etc.), update this list too or
 // offline mode will silently break for those assets.
+// Everything this game needs to boot offline — GENERATED, not maintained.
+// tools/stage.mjs rewrites the region below from the files the deploy actually
+// publishes (tools/inject-precache.mjs), so the list cannot drift from the
+// artifact and a content-hashed bundle name needs no hand edit. To leave a
+// file out, name it in PRECACHE_EXCLUDE in tools/stage.mjs — never here.
+//
+// What is checked in is a placeholder: service workers are off on loopback, so
+// a dev checkout never reads it.
+// arcade:precache-begin
 const ASSETS = [
   './',
   './index.html',
-  './manifest.json',
-  './icon.svg',
-  './visuals/tracer.js?v=2',
-  './visuals/spirograph.js?v=2',
-  './visuals/gallery.js?v=4',
-  './visuals/orbital.js?v=2',
-  './visuals/manager.js?v=2',
 ];
+// arcade:precache-end
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+    caches.open(CACHE_NAME).then(cache => Promise.all(
+      // Per-asset add(), not addAll(). addAll() rejects the WHOLE install on a
+      // single 404, so one missing file costs a returning player their entire
+      // offline shell — silently. A gap should cost one file and a log line.
+      ASSETS.map(asset => cache.add(asset).catch(err =>
+        console.warn('[sw] precache skipped', asset, err && err.message)))
+    ))
   );
   // Deliberately NOT skipWaiting(). The new worker installs and waits; the
   // launcher spots it and offers the player an explicit "update ready" reload,
@@ -99,7 +108,7 @@ self.addEventListener('fetch', event => {
   // Cache-first for static assets; cache successful fetches too, so assets
   // missing from ASSETS (or added later) still work offline next time.
   event.respondWith(
-    caches.match(event.request).then(cached => {
+    caches.match(event.request, { ignoreSearch: true }).then(cached => {
       if (cached) return cached;
       return fetch(event.request).then(response => {
         if (response.ok) {

--- a/tests/service-worker.test.js
+++ b/tests/service-worker.test.js
@@ -37,16 +37,21 @@ const PKG = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')); // rea
 const SCOPE = 'https://paulgibeault.github.io/pi-game/';
 
 /** Evaluate sw.js against a fake global scope and return the handles. */
-function loadWorker({ cacheKeys = [] } = {}) {
+function loadWorker({ cacheKeys = [], failAdd = null } = {}) {
   const deleted = [];
   const handlers = {};
-  const calls = { skipWaiting: 0, claim: 0, addAll: null };
+  const calls = { skipWaiting: 0, claim: 0, added: [] };
 
   const caches = {
     keys: async () => cacheKeys.slice(),
     delete: async (k) => { deleted.push(k); return true; },
     open: async () => ({
-      addAll: async (list) => { calls.addAll = list; },
+      // Per-asset add(), matching the shared template. `failAdd` makes one
+      // entry 404 so a test can prove the rest still cache.
+      add: async (asset) => {
+        if (asset === failAdd) throw new Error('404');
+        calls.added.push(asset);
+      },
       put: async () => {},
     }),
     match: async () => undefined,
@@ -133,15 +138,29 @@ test('install precaches and does NOT skipWaiting', async () => {
   const w = loadWorker();
   await w.fire('install');
 
-  assert.ok(w.calls.addAll && w.calls.addAll.length > 0, 'install should precache assets');
-  assert.ok(
-    w.calls.addAll.includes('./index.html'),
-    'the precache list should cover the app shell');
+  assert.ok(w.calls.added.length > 0, 'install should precache assets');
+  // Only the shell is asserted here. WHAT gets precached is no longer written
+  // in this file — tools/stage.mjs generates the list from the deploy artifact,
+  // so the checked-in array is a placeholder and this test would be asserting
+  // a fixture. Coverage of the real list lives in tools/verify-artifact.mjs,
+  // which fails on any published file the worker does not cache.
+  assert.ok(w.calls.added.includes('./index.html'),
+    'the app shell should always be precached');
   assert.strictEqual(
     w.calls.skipWaiting, 0,
     'install must not skipWaiting — the launcher\'s update prompt depends on ' +
     'the new worker waiting, and activating unannounced swaps the cache under ' +
     'a running game');
+});
+
+test('one missing asset does not cost the player the whole offline shell', async () => {
+  // The reason install() uses per-asset add() rather than addAll(): addAll()
+  // rejects entirely on a single 404, so one unpublished file silently leaves
+  // a returning player with no cache at all. A gap should cost one file.
+  const w = loadWorker({ failAdd: './index.html' });
+  await w.fire('install');
+  assert.ok(w.calls.added.length > 0,
+    'the surviving assets should still be cached when one entry 404s');
 });
 
 test('the launcher can activate a waiting worker on demand', async () => {

--- a/tools/inject-precache.mjs
+++ b/tools/inject-precache.mjs
@@ -1,0 +1,133 @@
+// The service worker's precache list, written from the artifact that actually
+// deploys instead of maintained by hand.
+//
+// IDENTICAL IN EVERY FLEET REPO. Do not edit one copy: change the canonical
+// file and re-copy it (GAME_INTEGRATION §13a). Like verify-artifact.mjs it is
+// a plain module, callable from any of the three test runners the fleet uses.
+//
+// WHY THIS EXISTS
+//
+// A hand-listed precache is three lists that must agree — index.html's tags,
+// sw.js's array, and what the deploy publishes — with nothing checking the
+// third against the second. Every drift mode showed up in the fleet at once:
+// an app shipped a bundled file the list could not name because the name is
+// content-hashed and changes every build; another listed paths in a form the
+// verifier's pattern never matched, so its entries went unchecked for months;
+// a third precached a file it no longer published. The failure is always the
+// same shape and always silent — install() rejects, or the cache is missing
+// the one file the game needs, and the only symptom is a game that works
+// online and breaks on a plane.
+//
+// So the list is generated. The input is the staged directory, which is the
+// bytes that deploy; nothing can be listed that isn't published, and nothing
+// published is omitted unless the app says so out loud.
+//
+// THE CONTRACT
+//
+// sw.js carries a generated region, and this rewrites what is between the
+// markers:
+//
+//   // arcade:precache-begin
+//   const ASSETS = [ './', './index.html' ];
+//   // arcade:precache-end
+//
+// The checked-in list is a placeholder — service workers are disabled on
+// loopback fleet-wide, so a dev checkout never uses it.
+//
+// An app that must leave something out of the cache — a diagnostic it ships
+// but never boots, a heavy asset it fetches on demand — declares it as
+// PRECACHE_EXCLUDE in tools/stage.mjs, where the rest of its per-app deploy
+// declaration already lives. That is deliberately the only knob, and it is
+// visible in review: verify-artifact.mjs asserts that every published file is
+// either precached or named there, so dropping a file out of the cache is a
+// decision someone writes down rather than an omission nobody notices.
+import fs from "node:fs";
+import path from "node:path";
+
+const BEGIN = "// arcade:precache-begin";
+const END = "// arcade:precache-end";
+
+/** Every file in the artifact, as forward-slash paths relative to its root. */
+export function artifactFiles(dir) {
+  const walk = (d) => fs.readdirSync(d, { withFileTypes: true }).flatMap((e) => {
+    const p = path.join(d, e.name);
+    return e.isDirectory() ? walk(p) : [path.relative(dir, p).split(path.sep).join("/")];
+  });
+  return walk(dir).sort();
+}
+
+/**
+ * Files that are published but never precached, whatever the app.
+ *
+ * sw.js itself: the worker is fetched by the browser's update check, which
+ * must reach the network to ever see a new version — caching it is how a
+ * worker makes itself permanent.
+ *
+ * Dotfiles: .DS_Store, .gitkeep and friends are never runtime assets. They
+ * should not be in the artifact at all, but a precache list is the wrong
+ * place to discover that, and addAll() rejecting on one would take the whole
+ * cache down with it.
+ */
+const NEVER = (rel) => rel === "sw.js" || rel.split("/").some((seg) => seg.startsWith("."));
+
+/**
+ * True if `rel` is excluded by `patterns`.
+ *
+ * Three forms, deliberately not a glob library: an exact path, a `dir/`
+ * prefix, and a `*.ext` suffix. Exclusions are read by whoever reviews a
+ * deploy, so the vocabulary stays small enough to be obvious at a glance —
+ * and anything subtler than "this file", "this directory" or "this kind of
+ * file" is a sign the artifact itself wants fixing, not the filter.
+ */
+export function isExcluded(rel, patterns) {
+  return patterns.some((p) => {
+    if (p.startsWith("*")) return rel.endsWith(p.slice(1));
+    if (p.endsWith("/")) return rel.startsWith(p);
+    return rel === p;
+  });
+}
+
+/** What the artifact in `dir` should precache, given the app's exclusions. */
+export function precacheList(dir, exclude = []) {
+  const entries = artifactFiles(dir)
+    .filter((f) => !NEVER(f) && !isExcluded(f, exclude))
+    .map((f) => `./${f}`);
+  // "./" is the directory itself — what a player actually navigates to. It is
+  // a distinct cache key from ./index.html and both are needed: the former is
+  // the URL, the latter is what a relative fetch resolves to.
+  return ["./", ...entries];
+}
+
+/**
+ * Rewrite the generated region of `dir/sw.js` from the staged artifact.
+ * Returns the entries written, or null if this artifact ships no worker.
+ */
+export function injectPrecache(dir, { exclude = [] } = {}) {
+  const swPath = path.join(dir, "sw.js");
+  if (!fs.existsSync(swPath)) return null;
+
+  const src = fs.readFileSync(swPath, "utf8");
+  const from = src.indexOf(BEGIN);
+  const to = src.indexOf(END);
+  if (from === -1 || to === -1 || to < from) {
+    throw new Error(
+      `sw.js has no generated precache region — expected ${BEGIN} … ${END}. ` +
+      `See tools/templates/game-sw.js (GAME_INTEGRATION §10).`
+    );
+  }
+
+  const entries = precacheList(dir, exclude);
+  const block = [
+    BEGIN,
+    "// Generated at stage time by tools/inject-precache.mjs from the files this",
+    "// deploy actually publishes. DO NOT EDIT BY HAND — your edit is overwritten",
+    "// on the next build. To leave a file out, add it to PRECACHE_EXCLUDE in",
+    "// tools/stage.mjs.",
+    "const ASSETS = [",
+    ...entries.map((e) => `  '${e}',`),
+    "];",
+  ].join("\n");
+
+  fs.writeFileSync(swPath, src.slice(0, from) + block + "\n" + src.slice(to));
+  return entries;
+}

--- a/tools/stage.mjs
+++ b/tools/stage.mjs
@@ -12,8 +12,24 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { injectPrecache } from "./inject-precache.mjs";
 
 export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Published, deliberately not precached. This is the only knob on the
+// generated list (tools/inject-precache.mjs), and it is reviewed rather than
+// silent: tools/verify-artifact.mjs fails the build on any published file that
+// is neither cached nor named here.
+//
+// The frozen chiptune archive, kept as provenance for the aesthetic this game
+// still ships. Everything else here is small and boots the game.
+//
+// visuals/*.js are now cached: index.html asks for them with a `?v=` suffix,
+// which the generated list cannot carry, so the worker matches ignoreSearch.
+export const PRECACHE_EXCLUDE = [
+  "audio/chiptune-archive.mjs",
+];
+
 
 // Dev-only: tooling, tests, notes, and local helpers. Everything else a repo
 // tracks is game content and ships.
@@ -42,6 +58,9 @@ export function stage(outDir) {
     fs.copyFileSync(path.join(ROOT, f), path.join(outDir, f));
     staged++;
   }
+  // Last, so it sees the finished artifact — the precache list is written from
+  // what is actually about to deploy, not from what anyone believes is.
+  injectPrecache(outDir, { exclude: PRECACHE_EXCLUDE });
   return { outDir, staged, total: files.length };
 }
 

--- a/tools/verify-artifact.mjs
+++ b/tools/verify-artifact.mjs
@@ -12,6 +12,7 @@
 //
 //   stage(outDir) -> { outDir }   // produce the deploy artifact in outDir
 //   ROOT                          // repo root
+//   PRECACHE_EXCLUDE              // optional; published but not precached
 //
 // Three lists have to agree and none of them check each other: index.html's
 // tags, the service worker's precache list, and what the deploy publishes.
@@ -19,11 +20,21 @@
 // them — every file is obviously present in a checkout. So stage for real
 // and read what came out.
 //
+// Since stage() generates the precache list from the artifact
+// (tools/inject-precache.mjs), the old direction of that check — "every
+// precached file is published" — can no longer fail; it is now a property of
+// how the list is built. The direction that CAN still fail is the reverse,
+// and it is the one that actually strands players offline: a file the deploy
+// publishes and the worker never caches. That is asserted below, with
+// PRECACHE_EXCLUDE as the app's written-down list of deliberate omissions.
+//
 // Usage: node tools/verify-artifact.mjs [--keep <dir>]
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { stage, ROOT } from "./stage.mjs";
+import { artifactFiles, isExcluded } from "./inject-precache.mjs";
+import * as staging from "./stage.mjs";
+const { stage, ROOT } = staging;
 
 /** Literal local src/href targets — an expression built in JS isn't a filename. */
 function indexRefs(dir) {
@@ -63,6 +74,22 @@ export function verify(dir) {
   for (const entry of sw.entries) {
     // "" is "./" — the directory itself, served as index.html.
     if (!has(entry || "index.html")) bad.push(`sw.js precaches ./${entry}, the deploy drops it`);
+  }
+
+  // The reverse: a published file the worker never caches is a file that is
+  // there online and gone on a plane. Silent by construction — every gate the
+  // fleet had was green while a bundled entry point sat outside the cache —
+  // so the artifact is what gets asked, and the only accepted answer for a
+  // missing file is that the app declared it missing on purpose.
+  if (fs.existsSync(path.join(dir, "sw.js"))) {
+    const cached = new Set(sw.entries.map((e) => e || "index.html"));
+    const exclude = staging.PRECACHE_EXCLUDE || [];
+    for (const f of artifactFiles(dir)) {
+      if (f === "sw.js" || f.split("/").some((s) => s.startsWith("."))) continue;
+      if (cached.has(f) || isExcluded(f, exclude)) continue;
+      bad.push(`the deploy publishes ${f}, sw.js never caches it ` +
+        `(precache it, or name it in PRECACHE_EXCLUDE in tools/stage.mjs)`);
+    }
   }
   // The game↔launcher boundary, checked from whichever side this repo is on.
   // A game loads /arcade-sdk.js and /arcade-audio.js from the launcher origin


### PR DESCRIPTION
Two commits from the fleet alignment pass (paulgibeault/paulgibeault.github.io#39; launcher side in paulgibeault/paulgibeault.github.io#122). Rebased onto main after the PR #27 SW fix and CI's v1.0.1 bump.

**Generated precache.** This repo is why the shared template's cache lookup now passes `ignoreSearch`: index.html loads the visuals modules as `visuals/tracer.js?v=2` etc., and the old hand list carried those exact strings. A generated list holds filenames — the filesystem has no query strings — so strict matching would have silently sent all five modules to the network. With `ignoreSearch` they hit, and the suffixes are redundant anyway now that CI's APP_VERSION keys the whole cache. Five files the game ships but never listed (the visuals modules, the icon) are now cached; `PRECACHE_EXCLUDE` holds only the chiptune archive, kept as provenance for the aesthetic this game deliberately ships.

**Arcade.loop.** The particle-and-visual loop parks itself via `stop()` when nothing is moving, wakes with idempotent `start()`, and leaves suspend/resume to the SDK.

Verification: 8 tests pass; rendered correctly in a real browser against a staged launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)